### PR TITLE
feat(search): add SQL Server full-text search

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ poetry run python manage.py runserver 0.0.0.0:8000
 - `POST /api/storage/presign` (JWT required) body: `{ "filename": "a.png", "content_type": "image/png" }`
 - `POST /api/attachments/init` (JWT + `X-Tenant` required) body: `{ "request_id": "<uuid>", "files": [{ "filename": "a.png", "content_type": "image/png" }] }`
 - `POST /api/attachments/finalize` (JWT + `X-Tenant` required) creates one grouped comment bubble plus attachment rows with `scanstatus=pending`
+- `GET /api/search?q=password` (JWT + `X-Tenant` required) searches request title/description, comment text, and attachment filenames with SQL Server Full-Text Search. Supports `types`, `status_id`, `assignee_id`, `flow_id`, `created_from`, `created_to`, `updated_from`, `updated_to`, `page`, and `page_size`.
 
 ## Notes
 - DB: SQL Server via `mssql-django` + `pyodbc`. Update env for your instance.

--- a/apps/rt/search.py
+++ b/apps/rt/search.py
@@ -1,0 +1,260 @@
+import re
+
+from django.db import connection
+
+MAX_SEARCH_TERMS = 8
+MAX_PAGE_SIZE = 100
+SEARCH_TYPES = {"request", "comment", "attachment"}
+
+
+class SearchValidationError(ValueError):
+    pass
+
+
+def normalize_search_types(value):
+    if not value:
+        return sorted(SEARCH_TYPES)
+
+    requested = {item.strip().lower() for item in value.split(",") if item.strip()}
+    invalid = requested - SEARCH_TYPES
+    if invalid:
+        raise SearchValidationError(
+            f"Unsupported search type(s): {', '.join(sorted(invalid))}."
+        )
+    if not requested:
+        return sorted(SEARCH_TYPES)
+    return sorted(requested)
+
+
+def build_fts_query(raw_query):
+    tokens = re.findall(r"[\w]+", raw_query or "", flags=re.UNICODE)
+    tokens = [token for token in tokens if token]
+    if not tokens:
+        raise SearchValidationError("Search query must include at least one term.")
+
+    terms = []
+    for token in tokens[:MAX_SEARCH_TERMS]:
+        escaped = token.replace('"', '""')
+        terms.append(f'"{escaped}*"')
+    return " AND ".join(terms)
+
+
+def search_requests(
+    *,
+    tenant_id,
+    raw_query,
+    page=1,
+    page_size=25,
+    types=None,
+    status_id=None,
+    assignee_id=None,
+    flow_id=None,
+    created_from=None,
+    created_to=None,
+    updated_from=None,
+    updated_to=None,
+):
+    page = max(int(page), 1)
+    page_size = min(max(int(page_size), 1), MAX_PAGE_SIZE)
+    offset = (page - 1) * page_size
+    fts_query = build_fts_query(raw_query)
+    search_types = normalize_search_types(types)
+    filters, filter_params = build_request_filters(
+        status_id=status_id,
+        assignee_id=assignee_id,
+        flow_id=flow_id,
+        created_from=created_from,
+        created_to=created_to,
+        updated_from=updated_from,
+        updated_to=updated_to,
+    )
+
+    selects = []
+    params = []
+    if "request" in search_types:
+        selects.append(
+            f"""
+            SELECT
+                r.RequestId,
+                r.HumanId,
+                r.Title,
+                r.Priority,
+                r.StatusId,
+                r.AssigneeId,
+                r.FlowId,
+                r.CreatedAt,
+                r.UpdatedAt,
+                'request' AS MatchSource,
+                30 AS MatchRank
+            FROM dbo.Request r
+            WHERE r.TenantId = %s
+              AND CONTAINS((r.Title, r.Description), %s)
+              {filters}
+            """
+        )
+        params.extend([str(tenant_id), fts_query, *filter_params])
+
+    if "comment" in search_types:
+        selects.append(
+            f"""
+            SELECT
+                r.RequestId,
+                r.HumanId,
+                r.Title,
+                r.Priority,
+                r.StatusId,
+                r.AssigneeId,
+                r.FlowId,
+                r.CreatedAt,
+                r.UpdatedAt,
+                'comment' AS MatchSource,
+                20 AS MatchRank
+            FROM dbo.Comment c
+            JOIN dbo.Request r
+              ON r.RequestId = c.RequestId
+             AND r.TenantId = c.TenantId
+            WHERE c.TenantId = %s
+              AND CONTAINS(c.MessageMd, %s)
+              {filters}
+            """
+        )
+        params.extend([str(tenant_id), fts_query, *filter_params])
+
+    if "attachment" in search_types:
+        selects.append(
+            f"""
+            SELECT
+                r.RequestId,
+                r.HumanId,
+                r.Title,
+                r.Priority,
+                r.StatusId,
+                r.AssigneeId,
+                r.FlowId,
+                r.CreatedAt,
+                r.UpdatedAt,
+                'attachment' AS MatchSource,
+                10 AS MatchRank
+            FROM dbo.Attachment a
+            JOIN dbo.Request r
+              ON r.RequestId = a.RequestId
+             AND r.TenantId = a.TenantId
+            WHERE a.TenantId = %s
+              AND CONTAINS(a.Filename, %s)
+              {filters}
+            """
+        )
+        params.extend([str(tenant_id), fts_query, *filter_params])
+
+    sql = f"""
+    WITH matched AS (
+        {" UNION ALL ".join(selects)}
+    ),
+    grouped AS (
+        SELECT
+            RequestId,
+            HumanId,
+            Title,
+            Priority,
+            StatusId,
+            AssigneeId,
+            FlowId,
+            CreatedAt,
+            UpdatedAt,
+            MAX(MatchRank) AS Rank,
+            STRING_AGG(MatchSource, ',') AS MatchSources
+        FROM matched
+        GROUP BY
+            RequestId,
+            HumanId,
+            Title,
+            Priority,
+            StatusId,
+            AssigneeId,
+            FlowId,
+            CreatedAt,
+            UpdatedAt
+    )
+    SELECT
+        RequestId,
+        HumanId,
+        Title,
+        Priority,
+        StatusId,
+        AssigneeId,
+        FlowId,
+        CreatedAt,
+        UpdatedAt,
+        Rank,
+        MatchSources,
+        COUNT(*) OVER() AS TotalCount
+    FROM grouped
+    ORDER BY Rank DESC, UpdatedAt DESC
+    OFFSET %s ROWS FETCH NEXT %s ROWS ONLY;
+    """
+    params.extend([offset, page_size])
+
+    with connection.cursor() as cursor:
+        cursor.execute(sql, params)
+        rows = cursor.fetchall()
+
+    total = int(rows[0][11]) if rows else 0
+    return {
+        "count": total,
+        "page": page,
+        "page_size": page_size,
+        "results": [serialize_search_row(row) for row in rows],
+    }
+
+
+def build_request_filters(
+    *,
+    status_id=None,
+    assignee_id=None,
+    flow_id=None,
+    created_from=None,
+    created_to=None,
+    updated_from=None,
+    updated_to=None,
+):
+    filters = []
+    params = []
+    if status_id:
+        filters.append("AND r.StatusId = %s")
+        params.append(str(status_id))
+    if assignee_id:
+        filters.append("AND r.AssigneeId = %s")
+        params.append(str(assignee_id))
+    if flow_id:
+        filters.append("AND r.FlowId = %s")
+        params.append(str(flow_id))
+    if created_from:
+        filters.append("AND r.CreatedAt >= %s")
+        params.append(created_from)
+    if created_to:
+        filters.append("AND r.CreatedAt <= %s")
+        params.append(created_to)
+    if updated_from:
+        filters.append("AND r.UpdatedAt >= %s")
+        params.append(updated_from)
+    if updated_to:
+        filters.append("AND r.UpdatedAt <= %s")
+        params.append(updated_to)
+    return "\n              ".join(filters), params
+
+
+def serialize_search_row(row):
+    match_sources = sorted({item for item in row[10].split(",") if item})
+    return {
+        "request_id": str(row[0]),
+        "human_id": row[1],
+        "title": row[2],
+        "priority": row[3],
+        "status_id": str(row[4]),
+        "assignee_id": str(row[5]) if row[5] else None,
+        "flow_id": str(row[6]),
+        "created_at": row[7].isoformat() if hasattr(row[7], "isoformat") else row[7],
+        "updated_at": row[8].isoformat() if hasattr(row[8], "isoformat") else row[8],
+        "rank": row[9],
+        "match_sources": match_sources,
+    }

--- a/apps/rt/serializers.py
+++ b/apps/rt/serializers.py
@@ -127,3 +127,19 @@ class ActivitySerializer(serializers.ModelSerializer):
     class Meta:
         model = Activity
         fields = ["activityid", "requestid", "actorid", "type", "payload", "createdat"]
+
+
+class SearchQuerySerializer(serializers.Serializer):
+    q = serializers.CharField(max_length=200, trim_whitespace=True)
+    page = serializers.IntegerField(required=False, min_value=1, default=1)
+    page_size = serializers.IntegerField(
+        required=False, min_value=1, max_value=100, default=25
+    )
+    types = serializers.CharField(required=False, allow_blank=True)
+    status_id = serializers.UUIDField(required=False)
+    assignee_id = serializers.UUIDField(required=False)
+    flow_id = serializers.UUIDField(required=False)
+    created_from = serializers.DateTimeField(required=False)
+    created_to = serializers.DateTimeField(required=False)
+    updated_from = serializers.DateTimeField(required=False)
+    updated_to = serializers.DateTimeField(required=False)

--- a/apps/rt/views.py
+++ b/apps/rt/views.py
@@ -14,6 +14,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from .models import Activity, Attachment, Comment, Request
+from .search import SearchValidationError, search_requests
 from .serializers import (
     ActivitySerializer,
     AttachmentFinalizeRequestSerializer,
@@ -22,6 +23,7 @@ from .serializers import (
     AttachmentSerializer,
     CommentSerializer,
     RequestSerializer,
+    SearchQuerySerializer,
 )
 
 
@@ -284,6 +286,60 @@ class AttachmentFinalizeView(APIView):
             },
             status=201,
         )
+
+
+class SearchView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        serializer = SearchQuerySerializer(data=request.query_params)
+        if not serializer.is_valid():
+            return Response(
+                {
+                    "code": "validation_error",
+                    "message": "Invalid search query.",
+                    "details": serializer.errors,
+                },
+                status=400,
+            )
+
+        tenant_id = getattr(request, "tenant_id", None)
+        if not tenant_id:
+            return Response(
+                {
+                    "code": "tenant_required",
+                    "message": "Tenant context missing.",
+                    "details": [],
+                },
+                status=400,
+            )
+
+        data = serializer.validated_data
+        try:
+            results = search_requests(
+                tenant_id=tenant_id,
+                raw_query=data["q"],
+                page=data["page"],
+                page_size=data["page_size"],
+                types=data.get("types"),
+                status_id=data.get("status_id"),
+                assignee_id=data.get("assignee_id"),
+                flow_id=data.get("flow_id"),
+                created_from=data.get("created_from"),
+                created_to=data.get("created_to"),
+                updated_from=data.get("updated_from"),
+                updated_to=data.get("updated_to"),
+            )
+        except SearchValidationError as exc:
+            return Response(
+                {
+                    "code": "validation_error",
+                    "message": str(exc),
+                    "details": [],
+                },
+                status=400,
+            )
+        return Response(results)
 
 
 def build_storage_url(object_key):

--- a/rt_api/urls.py
+++ b/rt_api/urls.py
@@ -15,6 +15,7 @@ from apps.rt.views import (
     AttachmentViewSet,
     CommentViewSet,
     RequestViewSet,
+    SearchView,
 )
 
 urlpatterns = [
@@ -38,6 +39,7 @@ urlpatterns = [
         AttachmentFinalizeView.as_view(),
         name="attachments-finalize",
     ),
+    path("api/search", SearchView.as_view(), name="search"),
     path("api/schema", SpectacularAPIView.as_view(), name="schema"),
     path(
         "api/docs", SpectacularSwaggerView.as_view(url_name="schema"), name="swagger-ui"

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,131 @@
+import uuid
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from apps.rt.search import SearchValidationError, build_fts_query, search_requests
+from apps.rt.views import SearchView
+
+
+class FakeCursor:
+    def __init__(self, rows):
+        self.rows = rows
+        self.sql = None
+        self.params = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def execute(self, sql, params):
+        self.sql = sql
+        self.params = params
+
+    def fetchall(self):
+        return self.rows
+
+
+def test_build_fts_query_uses_prefix_terms_and_strips_symbols():
+    query = build_fts_query('reset password"; DROP TABLE dbo.Request;')
+
+    assert (
+        query
+        == '"reset*" AND "password*" AND "DROP*" AND "TABLE*" AND "dbo*" AND "Request*"'
+    )
+    assert ";" not in query
+
+
+def test_build_fts_query_rejects_empty_terms():
+    with pytest.raises(SearchValidationError):
+        build_fts_query("!!!")
+
+
+def test_search_requests_builds_tenant_scoped_combined_fts_sql(monkeypatch):
+    tenant_id = uuid.uuid4()
+    status_id = uuid.uuid4()
+    request_id = uuid.uuid4()
+    flow_id = uuid.uuid4()
+    updated = datetime(2026, 5, 3, 12, 0, tzinfo=timezone.utc)
+    row = (
+        request_id,
+        "RT-2026-000123",
+        "Reset payroll password",
+        "normal",
+        status_id,
+        None,
+        flow_id,
+        updated,
+        updated,
+        30,
+        "request,comment,attachment",
+        1,
+    )
+    fake_cursor = FakeCursor([row])
+
+    monkeypatch.setattr("apps.rt.search.connection.cursor", lambda: fake_cursor)
+
+    results = search_requests(
+        tenant_id=tenant_id,
+        raw_query="reset password",
+        types="request,attachment",
+        status_id=status_id,
+        created_from=updated,
+        page=2,
+        page_size=10,
+    )
+
+    assert "FROM dbo.Request r" in fake_cursor.sql
+    assert "FROM dbo.Attachment a" in fake_cursor.sql
+    assert "FROM dbo.Comment c" not in fake_cursor.sql
+    assert "CONTAINS((r.Title, r.Description), %s)" in fake_cursor.sql
+    assert "CONTAINS(a.Filename, %s)" in fake_cursor.sql
+    assert fake_cursor.sql.count("r.TenantId = %s") == 1
+    assert fake_cursor.sql.count("a.TenantId = %s") == 1
+    assert str(tenant_id) in fake_cursor.params
+    assert str(status_id) in fake_cursor.params
+    assert updated in fake_cursor.params
+    assert fake_cursor.params[-2:] == [10, 10]
+    assert results["count"] == 1
+    assert results["page"] == 2
+    assert results["results"][0]["request_id"] == str(request_id)
+    assert results["results"][0]["match_sources"] == [
+        "attachment",
+        "comment",
+        "request",
+    ]
+
+
+def test_search_requests_rejects_unknown_type():
+    with pytest.raises(SearchValidationError):
+        search_requests(tenant_id=uuid.uuid4(), raw_query="reset", types="ticket")
+
+
+def test_search_view_returns_validation_error_for_blank_query():
+    request = SimpleNamespace(query_params={"q": ""}, tenant_id=uuid.uuid4())
+
+    response = SearchView().get(request)
+
+    assert response.status_code == 400
+    assert response.data["code"] == "validation_error"
+
+
+def test_search_view_dispatches_to_search_service(monkeypatch):
+    tenant_id = uuid.uuid4()
+    captured = {}
+
+    def fake_search_requests(**kwargs):
+        captured.update(kwargs)
+        return {"count": 0, "page": 1, "page_size": 25, "results": []}
+
+    monkeypatch.setattr("apps.rt.views.search_requests", fake_search_requests)
+    request = SimpleNamespace(query_params={"q": "reset"}, tenant_id=tenant_id)
+
+    response = SearchView().get(request)
+
+    assert response.status_code == 200
+    assert response.data["count"] == 0
+    assert captured["tenant_id"] == tenant_id
+    assert captured["raw_query"] == "reset"


### PR DESCRIPTION
## Summary
- add tenant-scoped GET /api/search backed by SQL Server Full-Text Search
- search request title/description, comment text, and attachment filenames
- support source/type, status, assignee, flow, date range, and pagination filters
- add focused tests for query safety, SQL construction, validation, and view dispatch

## Testing
- poetry run python manage.py check
- poetry run pytest -q
- poetry run ruff check .
- poetry run black . --check
- poetry run isort . --check --diff
- git diff --check

## Checklist
- [x] Read AGENTS.md
- [x] Title in Conventional Commit format
- [x] Tests added/updated
- [x] Lint/format checks pass
- [x] Tenant scoping validated in search SQL
- [x] Documentation updated