### PR TITLE
chore(api): harden sprint 1 smoke flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,12 @@ poetry run python manage.py runserver 0.0.0.0:8000
 - DB: SQL Server via `mssql-django` + `pyodbc`. Update env for your instance.
 - MinIO: pre-signed PUT URLs using boto3 S3 client.
 - CORS: open in dev; tighten later.
+
+## Sprint 1 Smoke Test
+1. Start API
+2. Login
+3. Set TOKEN
+4. Create request
+5. Add comment
+6. Upload attachments
+7. Search

--- a/apps/rt/search.py
+++ b/apps/rt/search.py
@@ -88,7 +88,7 @@ def search_requests(
                 30 AS MatchRank
             FROM dbo.Request r
             WHERE r.TenantId = %s
-              AND CONTAINS((r.Title, r.Description), %s)
+              AND CONTAINS((Title, Description), %s)
               {filters}
             """
         )
@@ -114,7 +114,7 @@ def search_requests(
               ON r.RequestId = c.RequestId
              AND r.TenantId = c.TenantId
             WHERE c.TenantId = %s
-              AND CONTAINS(c.MessageMd, %s)
+              AND CONTAINS(MessageMd, %s)
               {filters}
             """
         )
@@ -140,14 +140,14 @@ def search_requests(
               ON r.RequestId = a.RequestId
              AND r.TenantId = a.TenantId
             WHERE a.TenantId = %s
-              AND CONTAINS(a.Filename, %s)
+              AND CONTAINS(Filename, %s)
               {filters}
             """
         )
         params.extend([str(tenant_id), fts_query, *filter_params])
 
     sql = f"""
-    WITH matched AS (
+    ;WITH matched AS (
         {" UNION ALL ".join(selects)}
     ),
     grouped AS (

--- a/apps/rt/serializers.py
+++ b/apps/rt/serializers.py
@@ -46,6 +46,11 @@ class RequestSerializer(serializers.ModelSerializer):
 
 
 class CommentSerializer(serializers.ModelSerializer):
+    body = serializers.CharField(required=False, allow_blank=True, write_only=True)
+    message = serializers.CharField(source="messagemd", read_only=True)
+    visibility = serializers.CharField(required=False, allow_blank=True)
+    messagemd = serializers.CharField(required=False, allow_blank=True)
+
     class Meta:
         model = Comment
         fields = [
@@ -53,9 +58,20 @@ class CommentSerializer(serializers.ModelSerializer):
             "requestid",
             "authorid",
             "messagemd",
+            "message",
+            "body",
             "visibility",
             "createdat",
         ]
+        read_only_fields = ["commentid", "requestid", "authorid", "createdat"]
+
+    def validate(self, attrs):
+        body = attrs.pop("body", None)
+        if body is not None and "messagemd" not in attrs:
+            attrs["messagemd"] = body
+        attrs.setdefault("messagemd", "")
+        attrs.setdefault("visibility", "public")
+        return attrs
 
 
 class AttachmentSerializer(serializers.ModelSerializer):
@@ -120,7 +136,30 @@ class AttachmentFinalizeRequestSerializer(serializers.Serializer):
     request_id = serializers.UUIDField()
     group_id = serializers.UUIDField()
     message = serializers.CharField(allow_blank=True, required=False)
-    files = AttachmentFinalizeFileSerializer(many=True, allow_empty=False)
+    comment_markdown = serializers.CharField(
+        allow_blank=True, required=False, write_only=True
+    )
+    files = AttachmentFinalizeFileSerializer(
+        many=True, allow_empty=False, required=False
+    )
+    objects = AttachmentFinalizeFileSerializer(
+        many=True, allow_empty=False, required=False, write_only=True
+    )
+    idempotency_key = serializers.CharField(
+        max_length=120, required=False, allow_blank=True
+    )
+
+    def validate(self, attrs):
+        objects = attrs.pop("objects", None)
+        comment_markdown = attrs.pop("comment_markdown", None)
+        if "files" not in attrs and objects is not None:
+            attrs["files"] = objects
+        if "message" not in attrs and comment_markdown is not None:
+            attrs["message"] = comment_markdown
+        if "files" not in attrs:
+            raise serializers.ValidationError({"files": ["This field is required."]})
+        attrs.setdefault("message", "")
+        return attrs
 
 
 class ActivitySerializer(serializers.ModelSerializer):

--- a/apps/rt/views.py
+++ b/apps/rt/views.py
@@ -9,6 +9,7 @@ from django.db import connection, transaction
 from django.utils import timezone
 from rest_framework import mixins, permissions, viewsets
 from rest_framework.decorators import action
+from rest_framework.exceptions import NotFound, ValidationError
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -94,24 +95,47 @@ class CommentViewSet(
     permission_classes = [TenantPermission]
     serializer_class = CommentSerializer
 
+    def get_request_uuid(self):
+        request_id = self.kwargs.get("request_pk")
+        try:
+            return uuid.UUID(str(request_id))
+        except (TypeError, ValueError) as exc:
+            raise ValidationError(
+                {
+                    "code": "validation_error",
+                    "message": "Invalid request id.",
+                    "details": [{"field": "request_id", "message": "Invalid UUID."}],
+                }
+            ) from exc
+
+    def get_request(self):
+        request_id = self.get_request_uuid()
+        tenant_id = self.request.tenant_id
+        try:
+            return Request.objects.get(requestid=request_id, tenantid=tenant_id)
+        except Request.DoesNotExist as exc:
+            raise NotFound(
+                {
+                    "code": "not_found",
+                    "message": "Request not found for this tenant.",
+                    "details": [],
+                }
+            ) from exc
+
     def get_queryset(self):
         tenant_id = self.request.tenant_id
-        request_id = self.kwargs.get("request_pk")
+        request_id = self.get_request_uuid()
         return Comment.objects.filter(
             tenantid=tenant_id, requestid=request_id
         ).order_by("-createdat")
 
     def perform_create(self, serializer):
-        tenant_id = self.request.tenant_id
-        request_id = self.kwargs.get("request_pk")
-        if isinstance(tenant_id, str):
-            tenant_id = uuid.UUID(tenant_id)
-        if isinstance(request_id, str):
-            request_id = uuid.UUID(request_id)
+        req = self.get_request()
         serializer.save(
-            tenantid_id=tenant_id,
-            requestid_id=request_id,
-            authorid=str(self.request.user.id),
+            commentid=uuid.uuid4(),
+            tenantid=req.tenantid,
+            requestid=req,
+            authorid=req.requesterid,
             createdat=timezone.now(),
         )
 
@@ -120,9 +144,22 @@ class AttachmentViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
     permission_classes = [TenantPermission]
     serializer_class = AttachmentSerializer
 
+    def get_request_uuid(self):
+        request_id = self.kwargs.get("request_pk")
+        try:
+            return uuid.UUID(str(request_id))
+        except (TypeError, ValueError) as exc:
+            raise ValidationError(
+                {
+                    "code": "validation_error",
+                    "message": "Invalid request id.",
+                    "details": [{"field": "request_id", "message": "Invalid UUID."}],
+                }
+            ) from exc
+
     def get_queryset(self):
         tenant_id = self.request.tenant_id
-        request_id = self.kwargs.get("request_pk")
+        request_id = self.get_request_uuid()
         return Attachment.objects.filter(
             tenantid=tenant_id, requestid=request_id
         ).order_by("-createdat")
@@ -223,6 +260,7 @@ class AttachmentFinalizeView(APIView):
         # Use the request owner until auth_user -> dbo.User mapping exists.
         author = req.requesterid
         comment = Comment.objects.create(
+            commentid=uuid.uuid4(),
             tenantid=req.tenantid,
             requestid=req,
             authorid=author,

--- a/rt_api/urls.py
+++ b/rt_api/urls.py
@@ -40,6 +40,7 @@ urlpatterns = [
         name="attachments-finalize",
     ),
     path("api/search", SearchView.as_view(), name="search"),
+    path("api/search/requests", SearchView.as_view(), name="search-requests"),
     path("api/schema", SpectacularAPIView.as_view(), name="schema"),
     path(
         "api/docs", SpectacularSwaggerView.as_view(url_name="schema"), name="swagger-ui"
@@ -57,12 +58,12 @@ request_attachments = AttachmentViewSet.as_view({"get": "list"})
 
 urlpatterns += [
     path(
-        "api/requests/<uuid:request_pk>/comments",
+        "api/requests/<str:request_pk>/comments",
         request_comments,
         name="request-comments",
     ),
     path(
-        "api/requests/<uuid:request_pk>/attachments",
+        "api/requests/<str:request_pk>/attachments",
         request_attachments,
         name="request-attachments",
     ),

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -1,0 +1,72 @@
+import uuid
+from types import SimpleNamespace
+
+from django.urls import resolve
+
+from apps.rt.models import Flow, Request, Status, Tenant, User
+from apps.rt.serializers import CommentSerializer
+from apps.rt.views import CommentViewSet
+
+UPPER_REQUEST_ID = "9DC80633-F354-44D3-A4CE-B3B78A027D33"
+
+
+def test_uppercase_request_id_matches_comments_route():
+    match = resolve(f"/api/requests/{UPPER_REQUEST_ID}/comments")
+
+    assert match.url_name == "request-comments"
+    assert match.kwargs["request_pk"] == UPPER_REQUEST_ID
+
+
+def test_uppercase_request_id_matches_attachments_route():
+    match = resolve(f"/api/requests/{UPPER_REQUEST_ID}/attachments")
+
+    assert match.url_name == "request-attachments"
+    assert match.kwargs["request_pk"] == UPPER_REQUEST_ID
+
+
+def test_comment_serializer_accepts_body_alias_and_defaults_visibility():
+    serializer = CommentSerializer(data={"body": "Postman comment"})
+
+    assert serializer.is_valid(), serializer.errors
+    assert serializer.validated_data["messagemd"] == "Postman comment"
+    assert serializer.validated_data["visibility"] == "public"
+
+
+def test_comment_create_uses_tenant_scoped_request_and_requester(monkeypatch):
+    tenant_id = uuid.uuid4()
+    request_id = uuid.UUID(UPPER_REQUEST_ID)
+    tenant = Tenant(tenantid=tenant_id)
+    requester = User(userid=uuid.uuid4())
+    rt_request = Request(
+        requestid=request_id,
+        tenantid=tenant,
+        humanid="RT-2026-000001",
+        title="Comment test",
+        flowid=Flow(flowid=uuid.uuid4(), tenantid=tenant),
+        statusid=Status(statusid=uuid.uuid4(), tenantid=tenant),
+        priority="normal",
+        requesterid=requester,
+    )
+    captured_get = {}
+    captured_save = {}
+
+    def fake_get(**kwargs):
+        captured_get.update(kwargs)
+        return rt_request
+
+    class FakeSerializer:
+        def save(self, **kwargs):
+            captured_save.update(kwargs)
+
+    monkeypatch.setattr("apps.rt.views.Request.objects.get", fake_get)
+    view = CommentViewSet()
+    view.request = SimpleNamespace(tenant_id=tenant_id)
+    view.kwargs = {"request_pk": UPPER_REQUEST_ID}
+
+    view.perform_create(FakeSerializer())
+
+    assert captured_get == {"requestid": request_id, "tenantid": tenant_id}
+    assert isinstance(captured_save["commentid"], uuid.UUID)
+    assert captured_save["tenantid"] == tenant
+    assert captured_save["requestid"] == rt_request
+    assert captured_save["authorid"] == requester

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -3,6 +3,7 @@ from datetime import datetime, timezone
 from types import SimpleNamespace
 
 import pytest
+from django.urls import resolve
 
 from apps.rt.search import SearchValidationError, build_fts_query, search_requests
 from apps.rt.views import SearchView
@@ -26,6 +27,12 @@ class FakeCursor:
 
     def fetchall(self):
         return self.rows
+
+
+def test_search_requests_postman_route_alias_resolves():
+    match = resolve("/api/search/requests")
+
+    assert match.url_name == "search-requests"
 
 
 def test_build_fts_query_uses_prefix_terms_and_strips_symbols():
@@ -80,8 +87,9 @@ def test_search_requests_builds_tenant_scoped_combined_fts_sql(monkeypatch):
     assert "FROM dbo.Request r" in fake_cursor.sql
     assert "FROM dbo.Attachment a" in fake_cursor.sql
     assert "FROM dbo.Comment c" not in fake_cursor.sql
-    assert "CONTAINS((r.Title, r.Description), %s)" in fake_cursor.sql
-    assert "CONTAINS(a.Filename, %s)" in fake_cursor.sql
+    assert fake_cursor.sql.lstrip().startswith(";WITH matched AS")
+    assert "CONTAINS((Title, Description), %s)" in fake_cursor.sql
+    assert "CONTAINS(Filename, %s)" in fake_cursor.sql
     assert fake_cursor.sql.count("r.TenantId = %s") == 1
     assert fake_cursor.sql.count("a.TenantId = %s") == 1
     assert str(tenant_id) in fake_cursor.params

--- a/tests/test_uploads.py
+++ b/tests/test_uploads.py
@@ -136,6 +136,7 @@ def test_attachment_finalize_creates_one_comment_and_grouped_attachments(monkeyp
     assert response.data["group_id"] == str(group_id)
     assert response.data["comment_id"] == str(comment.commentid)
     assert len(response.data["attachments"]) == 2
+    assert isinstance(created_comments[0]["commentid"], uuid.UUID)
     assert created_comments[0]["groupid"] == str(group_id)
     assert created_comments[0]["messagemd"] == "Uploaded two files"
     assert len(created_attachments) == 2
@@ -145,3 +146,63 @@ def test_attachment_finalize_creates_one_comment_and_grouped_attachments(monkeyp
         f"rt-attachments/uploads/{group_id}/screen.png"
     )
     assert created_activities[0]["type"] == "attachments.finalized"
+
+
+def test_attachment_finalize_accepts_postman_object_payload(monkeypatch):
+    tenant_id = uuid.uuid4()
+    request_id = uuid.uuid4()
+    group_id = uuid.uuid4()
+    tenant = Tenant(tenantid=tenant_id)
+    requester = User(userid=uuid.uuid4())
+    rt_request = Request(
+        requestid=request_id,
+        tenantid=tenant,
+        humanid="RT-2026-000001",
+        title="Postman upload test",
+        flowid=Flow(flowid=uuid.uuid4(), tenantid=tenant),
+        statusid=Status(statusid=uuid.uuid4(), tenantid=tenant),
+        priority="normal",
+        requesterid=requester,
+    )
+    comment = Comment(commentid=uuid.uuid4())
+    created_comments = []
+    created_attachments = []
+
+    monkeypatch.setattr(
+        "apps.rt.views.Request.objects.get",
+        lambda **kwargs: rt_request,
+    )
+    monkeypatch.setattr(
+        "apps.rt.views.Comment.objects.create",
+        lambda **kwargs: created_comments.append(kwargs) or comment,
+    )
+    monkeypatch.setattr(
+        "apps.rt.views.Attachment.objects.bulk_create",
+        lambda attachments: created_attachments.extend(attachments),
+    )
+    monkeypatch.setattr("apps.rt.views.Activity.objects.create", lambda **kwargs: None)
+
+    request = SimpleNamespace(
+        tenant_id=tenant_id,
+        data={
+            "request_id": str(request_id),
+            "group_id": str(group_id),
+            "comment_markdown": "Finalized Postman upload.",
+            "objects": [
+                {
+                    "object_key": f"uploads/{group_id}/postman-vpn-smoke.txt",
+                    "filename": "postman-vpn-smoke.txt",
+                    "content_type": "text/plain",
+                    "size_bytes": 128,
+                }
+            ],
+            "idempotency_key": "postman-finalize-123",
+        },
+    )
+    post = AttachmentFinalizeView.post.__wrapped__
+
+    response = post(AttachmentFinalizeView(), request)
+
+    assert response.status_code == 201
+    assert created_comments[0]["messagemd"] == "Finalized Postman upload."
+    assert created_attachments[0].filename == "postman-vpn-smoke.txt"


### PR DESCRIPTION
## Summary
- accept uppercase SQL Server GUIDs for nested comments and attachments routes
- harden comment create payloads and generate CommentId explicitly for unmanaged SQL Server models
- accept Postman finalize payload aliases: comment_markdown, objects, and idempotency_key
- add /api/search/requests route alias and fix SQL Server FTS syntax
- document Sprint 1 smoke test flow in README

## Testing
- poetry run python manage.py check
- poetry run pytest -q
- poetry run ruff check .
- poetry run black . --check
- poetry run isort . --check --diff
- git diff --check
- Postman smoke: health, auth, requests, comments, uploads, search

## Checklist
- [x] Read AGENTS.md
- [x] Title in Conventional Commit format
- [x] Tests added/updated
- [x] Lint/format checks pass
- [x] Tenant-scoped routes preserved
- [x] README smoke test section added