### PR TITLE
feat(requests): add request detail API

### DIFF
--- a/apps/rt/serializers.py
+++ b/apps/rt/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from .models import Activity, Attachment, Comment, Request
+from .models import Activity, Attachment, Comment, Flow, Request, Status, User
 
 # No necesitas importar Flow, Status, User aquí si usas UUIDField
 # from .models import Flow, Status, User
@@ -43,6 +43,78 @@ class RequestSerializer(serializers.ModelSerializer):
     # if "requestid" not in validated_data or not validated_data.get("requestid"):
     #     validated_data["requestid"] = uuid.uuid4()
     # return super().create(validated_data)
+
+
+class UserSummarySerializer(serializers.ModelSerializer):
+    user_id = serializers.UUIDField(source="userid", read_only=True)
+    display_name = serializers.CharField(source="displayname", read_only=True)
+    employee_code = serializers.CharField(source="employeecode", read_only=True)
+    avatar_url = serializers.CharField(source="avatarurl", read_only=True)
+
+    class Meta:
+        model = User
+        fields = ["user_id", "email", "display_name", "employee_code", "avatar_url"]
+
+
+class FlowSummarySerializer(serializers.ModelSerializer):
+    flow_id = serializers.UUIDField(source="flowid", read_only=True)
+
+    class Meta:
+        model = Flow
+        fields = ["flow_id", "name", "description"]
+
+
+class StatusSummarySerializer(serializers.ModelSerializer):
+    status_id = serializers.UUIDField(source="statusid", read_only=True)
+    is_terminal = serializers.BooleanField(source="isterminal", read_only=True)
+
+    class Meta:
+        model = Status
+        fields = ["status_id", "name", "category", "is_terminal"]
+
+
+class RequestDetailSerializer(serializers.ModelSerializer):
+    request_id = serializers.UUIDField(source="requestid", read_only=True)
+    human_id = serializers.CharField(source="humanid", read_only=True)
+    flow = FlowSummarySerializer(source="flowid", read_only=True)
+    status = StatusSummarySerializer(source="statusid", read_only=True)
+    requester = UserSummarySerializer(source="requesterid", read_only=True)
+    assignee = UserSummarySerializer(source="assigneeid", read_only=True)
+    flow_id = serializers.UUIDField(source="flowid_id", read_only=True)
+    status_id = serializers.UUIDField(source="statusid_id", read_only=True)
+    requester_id = serializers.UUIDField(source="requesterid_id", read_only=True)
+    assignee_id = serializers.UUIDField(source="assigneeid_id", read_only=True)
+    custom_fields = serializers.CharField(source="customfields", read_only=True)
+    due_at = serializers.DateTimeField(source="dueat", read_only=True)
+    created_at = serializers.DateTimeField(source="createdat", read_only=True)
+    updated_at = serializers.DateTimeField(source="updatedat", read_only=True)
+    tags = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Request
+        fields = [
+            "request_id",
+            "human_id",
+            "title",
+            "description",
+            "priority",
+            "flow_id",
+            "flow",
+            "status_id",
+            "status",
+            "requester_id",
+            "requester",
+            "assignee_id",
+            "assignee",
+            "custom_fields",
+            "tags",
+            "due_at",
+            "created_at",
+            "updated_at",
+        ]
+
+    def get_tags(self, obj):
+        return []
 
 
 class CommentSerializer(serializers.ModelSerializer):

--- a/apps/rt/views.py
+++ b/apps/rt/views.py
@@ -23,6 +23,7 @@ from .serializers import (
     AttachmentInitResponseSerializer,
     AttachmentSerializer,
     CommentSerializer,
+    RequestDetailSerializer,
     RequestSerializer,
     SearchQuerySerializer,
 )
@@ -47,6 +48,18 @@ class BaseTenantViewSet(viewsets.ModelViewSet):
 class RequestViewSet(BaseTenantViewSet):
     queryset = Request.objects.all().order_by("-updatedat")
     serializer_class = RequestSerializer
+
+    def get_queryset(self):
+        return (
+            super()
+            .get_queryset()
+            .select_related("flowid", "statusid", "requesterid", "assigneeid")
+        )
+
+    def get_serializer_class(self):
+        if self.action in {"retrieve", "detail_bundle"}:
+            return RequestDetailSerializer
+        return super().get_serializer_class()
 
     def perform_create(self, serializer):
         validated_data = serializer.validated_data
@@ -82,10 +95,40 @@ class RequestViewSet(BaseTenantViewSet):
 
     @action(detail=True, methods=["get"])
     def activity(self, request, pk=None):
+        return self._activity_response(request, pk)
+
+    @action(detail=True, methods=["get"], url_path="activities")
+    def activities(self, request, pk=None):
+        return self._activity_response(request, pk)
+
+    @action(detail=True, methods=["get"], url_path="detail")
+    def detail_bundle(self, request, pk=None):
+        rt_request = self.get_object()
         tenant_id = request.tenant_id
-        items = Activity.objects.filter(tenantid=tenant_id, requestid=pk).order_by(
-            "-createdat"
+        comments = Comment.objects.filter(
+            tenantid=tenant_id, requestid=rt_request.requestid
+        ).order_by("-createdat")
+        attachments = Attachment.objects.filter(
+            tenantid=tenant_id, requestid=rt_request.requestid
+        ).order_by("-createdat")
+        activity = Activity.objects.filter(
+            tenantid=tenant_id, requestid=rt_request.requestid
+        ).order_by("-createdat")
+        return Response(
+            {
+                "request": RequestDetailSerializer(rt_request).data,
+                "comments": CommentSerializer(comments, many=True).data,
+                "attachments": AttachmentSerializer(attachments, many=True).data,
+                "activity": ActivitySerializer(activity, many=True).data,
+            }
         )
+
+    def _activity_response(self, request, pk=None):
+        rt_request = self.get_object()
+        tenant_id = request.tenant_id
+        items = Activity.objects.filter(
+            tenantid=tenant_id, requestid=rt_request.requestid
+        ).order_by("-createdat")
         return Response(ActivitySerializer(items, many=True).data)
 
 

--- a/rt_api/urls.py
+++ b/rt_api/urls.py
@@ -63,8 +63,18 @@ urlpatterns += [
         name="request-comments",
     ),
     path(
+        "api/requests/<str:request_pk>/comments/",
+        request_comments,
+        name="request-comments-slash",
+    ),
+    path(
         "api/requests/<str:request_pk>/attachments",
         request_attachments,
         name="request-attachments",
+    ),
+    path(
+        "api/requests/<str:request_pk>/attachments/",
+        request_attachments,
+        name="request-attachments-slash",
     ),
 ]

--- a/tests/test_request_detail.py
+++ b/tests/test_request_detail.py
@@ -1,0 +1,94 @@
+import uuid
+
+from django.urls import resolve
+from django.utils import timezone
+
+from apps.rt.models import Flow, Request, Status, Tenant, User
+from apps.rt.serializers import RequestDetailSerializer
+
+UPPER_REQUEST_ID = "9DC80633-F354-44D3-A4CE-B3B78A027D33"
+
+
+def build_request():
+    tenant = Tenant(tenantid=uuid.uuid4())
+    flow = Flow(
+        flowid=uuid.uuid4(),
+        tenantid=tenant,
+        name="IT Support",
+        description="Internal service desk",
+    )
+    status = Status(
+        statusid=uuid.uuid4(),
+        tenantid=tenant,
+        flowid=flow,
+        name="In Progress",
+        category="in_progress",
+        isterminal=False,
+    )
+    requester = User(
+        userid=uuid.uuid4(),
+        email="requester@example.com",
+        displayname="Request Owner",
+        employeecode="E-100",
+        avatarurl="https://example.com/avatar.png",
+    )
+    assignee = User(
+        userid=uuid.uuid4(),
+        email="assignee@example.com",
+        displayname="Assigned Agent",
+        employeecode="E-200",
+    )
+    now = timezone.now()
+    return Request(
+        requestid=uuid.UUID(UPPER_REQUEST_ID),
+        tenantid=tenant,
+        humanid="RT-2026-000001",
+        title="VPN access",
+        description="Need VPN access for travel.",
+        flowid=flow,
+        statusid=status,
+        priority="normal",
+        requesterid=requester,
+        assigneeid=assignee,
+        customfields='{"country": "SV"}',
+        dueat=now,
+        createdat=now,
+        updatedat=now,
+    )
+
+
+def test_request_detail_routes_resolve():
+    assert (
+        resolve(f"/api/requests/{UPPER_REQUEST_ID}/detail/").url_name
+        == "requests-detail-bundle"
+    )
+    assert (
+        resolve(f"/api/requests/{UPPER_REQUEST_ID}/activities/").url_name
+        == "requests-activities"
+    )
+
+
+def test_nested_comments_and_attachments_accept_trailing_slash():
+    comments = resolve(f"/api/requests/{UPPER_REQUEST_ID}/comments/")
+    attachments = resolve(f"/api/requests/{UPPER_REQUEST_ID}/attachments/")
+
+    assert comments.url_name == "request-comments-slash"
+    assert comments.kwargs["request_pk"] == UPPER_REQUEST_ID
+    assert attachments.url_name == "request-attachments-slash"
+    assert attachments.kwargs["request_pk"] == UPPER_REQUEST_ID
+
+
+def test_request_detail_serializer_returns_header_and_related_summaries():
+    data = RequestDetailSerializer(build_request()).data
+
+    assert data["request_id"] == UPPER_REQUEST_ID.lower()
+    assert data["human_id"] == "RT-2026-000001"
+    assert data["title"] == "VPN access"
+    assert data["flow"]["name"] == "IT Support"
+    assert data["status"]["category"] == "in_progress"
+    assert data["requester"]["display_name"] == "Request Owner"
+    assert data["assignee"]["email"] == "assignee@example.com"
+    assert data["custom_fields"] == '{"country": "SV"}'
+    assert data["tags"] == []
+    assert data["created_at"]
+    assert data["updated_at"]


### PR DESCRIPTION
## Summary
- add rich request detail serialization with requester, assignee, status, and flow summaries
- add combined request detail endpoint with comments, attachments, and activity
- add activities and trailing-slash nested route aliases for the detail page
- cover request detail route and serializer behavior with tests

## Validation
- poetry run python manage.py check
- poetry run pytest -q
- poetry run ruff check .
- poetry run black . --check
- poetry run isort . --check --diff
- git diff --check