### PR TITLE
docs(codex): add planning guidance

### DIFF
--- a/.agent/PLANS.md
+++ b/.agent/PLANS.md
@@ -1,0 +1,75 @@
+# PLANS.md — Codex ExecPlans Standard
+
+This file defines how Codex must create and maintain ExecPlans in this repository.
+
+An ExecPlan is a self-contained implementation plan that a coding agent or a new engineer can follow without needing hidden chat context. Use an ExecPlan for complex features, cross-file refactors, security-sensitive changes, workflow changes, or any task expected to affect multiple modules.
+
+## Non-negotiable rules
+
+1. Read this file and the repository `AGENTS.md` in full before creating or executing an ExecPlan.
+2. Every ExecPlan must be self-contained. Do not rely on prior chat memory.
+3. Every ExecPlan must explain the user-visible outcome first.
+4. Every ExecPlan must name exact repository-relative files and commands.
+5. Every ExecPlan must contain acceptance criteria and verification steps.
+6. Keep `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` updated.
+7. For API or UI contract changes, update OpenAPI or design tokens before implementation.
+8. Run the repo checks listed in `AGENTS.md` before suggesting a commit or PR.
+9. For auth, tenancy, uploads, search SQL, database, permissions, or workflows, include negative tests.
+
+## Where plans live
+
+- Shared standard: `.agent/PLANS.md`
+- Active plans: `docs/plans/sprint-<n>/<feature>-execplan.md`
+- Temporary plans: `.agent/tmp/` and must not be committed unless promoted.
+
+## ExecPlan skeleton
+
+# <Short action-oriented feature title>
+
+## Purpose
+
+Explain what a user or operator can do after this change that they cannot do now. Include how to observe it working.
+
+## Repository orientation
+
+Explain the relevant files and folders in this repo. Name exact repository-relative paths.
+
+## Current behavior
+
+Describe what the app does today.
+
+## Desired behavior
+
+Describe target behavior, edge cases, failure behavior, and security expectations.
+
+## Scope
+
+State what is in scope and out of scope.
+
+## Implementation plan
+
+Write step-by-step milestones. Each milestone names files to edit, commands to run, and expected observations.
+
+## Tests and verification
+
+List unit, integration, manual, Postman, or browser checks. Include exact commands.
+
+## Acceptance criteria
+
+Use behavior-oriented criteria.
+
+## Progress
+
+Use checkboxes and keep updated.
+
+## Surprises & Discoveries
+
+Record facts discovered during implementation.
+
+## Decision Log
+
+Record decisions and why they were made.
+
+## Outcomes & Retrospective
+
+At completion, summarize what changed, what works, what remains, and follow-up issues.

--- a/.agent/code_review.md
+++ b/.agent/code_review.md
@@ -1,0 +1,20 @@
+# code_review.md — Codex Review Standard
+
+Use this checklist when asking Codex to review a branch, PR diff, uncommitted changes, or a commit.
+
+## Review priorities
+
+1. Correctness: Does the change implement the requested behavior?
+2. Tenant isolation: Can one tenant access another tenant's data?
+3. Security: Are auth, permissions, uploads, SQL, and secrets handled safely?
+4. API contract: Does public JSON use clean fields like `request_id`, `flow_id`, `created_at`?
+5. Error handling: Are client mistakes returned as 400/401/403/404 instead of 500?
+6. Tests: Are relevant tests added or updated?
+7. Maintainability: Is logic in the correct service/component layer?
+8. UX: Are loading, empty, error, and success states handled?
+9. Documentation: Are OpenAPI, README, or demo docs updated?
+10. Regression risk: What existing behavior might break?
+
+## Codex review prompt
+
+Review this branch against `main`. Read `AGENTS.md`, `.agent/PLANS.md`, and the active ExecPlan in `docs/plans` first. Focus on correctness, tenant isolation, public API naming, test coverage, and regressions. Do not make code changes yet. Return prioritized findings with file paths and suggested fixes.

--- a/.codex/config.toml.example
+++ b/.codex/config.toml.example
@@ -1,0 +1,8 @@
+# .codex/config.toml.example
+# Copy to .codex/config.toml if you want repo-local Codex defaults.
+# Keep approvals and sandboxing conservative unless you intentionally loosen them.
+# Recommended project style:
+# - Plan first for multi-file features.
+# - Ask before destructive operations.
+# - Run repo-specific checks before suggesting a commit.
+# - Keep changes small and PR-focused.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,20 @@
 - Optional OpenSearch backend for search with query DSL.
 - SSO/OIDC path with well-known discovery; keep JWT as fallback for dev.
 
+## 15. Codex ExecPlans
+
+For complex features, multi-file refactors, security-sensitive changes, API contract changes, database changes, upload/search changes, or Sprint work, Codex must create or update an ExecPlan following `.agent/PLANS.md`.
+
+ExecPlans must live under `docs/plans/`. The active ExecPlan must be updated throughout implementation, especially `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective`.
+
+For small single-file fixes, an ExecPlan is optional, but Codex must still state goal, constraints, and done criteria before editing.
+
+Before implementation, Codex must read:
+1. `AGENTS.md`
+2. `.agent/PLANS.md`
+3. the active ExecPlan for the branch
+4. any repo-specific design/API/token files referenced by the plan
+
 ---
 
 *This AGENTS.md reflects the design and constraints agreed for the Request Tracker modernization project.*

--- a/docs/codex-prompts.md
+++ b/docs/codex-prompts.md
@@ -1,0 +1,13 @@
+# Codex prompts — rt-api
+
+## Plan Day 3–4
+
+Read `AGENTS.md` and `.agent/PLANS.md` in full. Update `docs/plans/sprint-2/api-full-request-lifecycle-execplan.md`. The next milestone is Create Request full flow. Do not write code yet. Inspect serializers, models, URLs, services, and tests. Include clean public API naming, validation, tenant enforcement, OpenAPI updates, and pytest/Postman checks.
+
+## Implement next milestone
+
+Read `AGENTS.md`, `.agent/PLANS.md`, and the active ExecPlan. Implement only the next unchecked milestone. Keep the ExecPlan updated. Run tests before final response.
+
+## Review
+
+Review this branch against `main` using `.agent/code_review.md`. Focus on tenant isolation, 400 vs 500 errors, SQL safety, public API names, and test coverage.

--- a/docs/plans/sprint-2/api-full-request-lifecycle-execplan.md
+++ b/docs/plans/sprint-2/api-full-request-lifecycle-execplan.md
@@ -1,0 +1,76 @@
+# Sprint 2 API ExecPlan — Full Request Lifecycle
+
+## Purpose
+
+This plan completes the backend side of the request lifecycle. After the change, users can create a request with clean public API fields, open a full request detail payload, transition or close the request, see dashboard summary counts, and trigger baseline notification events.
+
+## Repository orientation
+
+This plan applies to `rt-api`. Relevant areas: `apps/rt/models.py`, `apps/rt/serializers/`, `apps/rt/views/`, `apps/rt/services/`, `rt_api/urls.py`, OpenAPI files, `AGENTS.md`, and `.agent/PLANS.md`.
+
+## Current behavior
+
+Sprint 1 has JWT auth, tenant enforcement, request models, comments, grouped uploads, search, and dashboard usage. Some APIs may still expose internal Django field names like `flowid_id`.
+
+## Desired behavior
+
+Expose clean public JSON fields: `request_id`, `human_id`, `flow_id`, `status_id`, `requester_id`, `assignee_id`, `created_at`, and `updated_at`. Add request detail, create flow hardening, transitions, dashboard summary, and notification baseline.
+
+## Scope
+
+In scope: API field cleanup, request detail endpoint, create request hardening, transition/close/reopen endpoints, dashboard summary endpoint, notification service, tests, OpenAPI updates. Out of scope: OIDC/AD, Channels, SLA engine, full admin workflow UI.
+
+## Implementation plan
+
+### Milestone 1: Public API naming cleanup
+
+Update serializers so inputs and outputs use clean snake_case fields. Keep internal model names private. Add tests for invalid GUIDs returning 400 instead of 500.
+
+### Milestone 2: Request detail payload
+
+Add or harden `GET /api/requests/{id}/detail/` or equivalent detail response. Include request header, requester, assignee, flow, status, comments, attachments, activity, and tags.
+
+### Milestone 3: Create request full API flow
+
+Validate flow/status relationship, generate `HumanId`, assign tenant, create `Activity` type `request.created`, and return clean JSON.
+
+### Milestone 4: Workflow transitions
+
+Add `available-transitions`, `transition`, `close`, and `reopen` endpoints. Validate allowed transitions, create optional comment, and create activity.
+
+### Milestone 5: Dashboard summary
+
+Add `GET /api/dashboard/summary/` returning open, in_progress, waiting, closed, due_today, overdue, assigned_to_me, and unassigned.
+
+### Milestone 6: Notification baseline
+
+Add `apps/rt/services/notification_service.py`. Send Mailhog-visible emails for request created, assigned, comment added, and closed. Email failure must not break the main action.
+
+## Tests and verification
+
+Run `poetry run pytest`. Manually verify Postman create request, request detail, transition/close, dashboard summary, and Mailhog email.
+
+## Acceptance criteria
+
+Public API no longer requires internal fields; request detail supports web; transitions work; dashboard summary exists; notifications work locally; OpenAPI is updated; tests pass.
+
+## Progress
+
+- [ ] Milestone 1 completed.
+- [ ] Milestone 2 completed.
+- [ ] Milestone 3 completed.
+- [ ] Milestone 4 completed.
+- [ ] Milestone 5 completed.
+- [ ] Milestone 6 completed.
+
+## Surprises & Discoveries
+
+Record findings here.
+
+## Decision Log
+
+Record decisions here.
+
+## Outcomes & Retrospective
+
+Complete after merge.

--- a/docs/plans/sprint-3/api-admin-configuration-execplan.md
+++ b/docs/plans/sprint-3/api-admin-configuration-execplan.md
@@ -1,0 +1,10 @@
+# Sprint 3 API ExecPlan — Admin and Configuration APIs
+
+Purpose: add tenant-scoped admin APIs for workflows, statuses, transitions, users, memberships, roles, and permissions.
+
+Progress:
+- [ ] Admin workflow CRUD.
+- [ ] Admin user/membership CRUD.
+- [ ] Role and permission assignment.
+- [ ] Audit and tests.
+- [ ] OpenAPI update.


### PR DESCRIPTION
## Summary
- add Codex planning and code-review guidance files
- add example Codex config and reusable prompt notes
- add Sprint 2 and Sprint 3 execution-plan docs
- update AGENTS.md with execution-plan workflow guidance

## Validation
- pre-commit hooks from git commit passed: merge conflict check, end-of-file fixer, trailing whitespace
- docs-only change; no backend test suite run