### PR TITLE
feat(requests): harden request creation

### DIFF
--- a/apps/rt/serializers.py
+++ b/apps/rt/serializers.py
@@ -1,48 +1,104 @@
 from rest_framework import serializers
 
-from .models import Activity, Attachment, Comment, Flow, Request, Status, User
-
-# No necesitas importar Flow, Status, User aquí si usas UUIDField
-# from .models import Flow, Status, User
+from .models import (
+    Activity,
+    Attachment,
+    Comment,
+    Flow,
+    Membership,
+    Request,
+    Status,
+    User,
+)
 
 
 class RequestSerializer(serializers.ModelSerializer):
-    # --- INICIO DEL CAMBIO ---
-    # Renombramos los campos para que coincidan directamente con los atributos del modelo
-    # y eliminamos el parámetro `source`.
-    flowid_id = serializers.UUIDField()
-    statusid_id = serializers.UUIDField()
-    requesterid_id = serializers.UUIDField()
-    assigneeid_id = serializers.UUIDField(required=False, allow_null=True)
-    # --- FIN DEL CAMBIO ---
+    VALID_PRIORITIES = {"low", "normal", "high", "urgent"}
+
+    request_id = serializers.UUIDField(source="requestid", read_only=True)
+    human_id = serializers.CharField(source="humanid", read_only=True)
+    flow_id = serializers.UUIDField(source="flowid_id")
+    status_id = serializers.UUIDField(source="statusid_id")
+    requester_id = serializers.UUIDField(source="requesterid_id")
+    assignee_id = serializers.UUIDField(
+        source="assigneeid_id", required=False, allow_null=True
+    )
+    custom_fields = serializers.CharField(
+        source="customfields", required=False, allow_blank=True, allow_null=True
+    )
+    due_at = serializers.DateTimeField(source="dueat", required=False, allow_null=True)
+    created_at = serializers.DateTimeField(source="createdat", read_only=True)
+    updated_at = serializers.DateTimeField(source="updatedat", read_only=True)
 
     class Meta:
         model = Request
-        # Actualizamos la lista de campos para reflejar los nuevos nombres
         fields = [
-            "requestid",
-            "humanid",
+            "request_id",
+            "human_id",
             "title",
             "description",
-            "flowid_id",
-            "statusid_id",
-            "requesterid_id",
-            "assigneeid_id",
             "priority",
-            "dueat",
-            "createdat",
-            "updatedat",
+            "flow_id",
+            "status_id",
+            "requester_id",
+            "assignee_id",
+            "custom_fields",
+            "due_at",
+            "created_at",
+            "updated_at",
         ]
-        read_only_fields = ["requestid", "humanid", "createdat", "updatedat"]
 
-    # def create(self, validated_data):
-    # Opcional pero recomendado:
-    # Tu tabla ya genera el RequestId con DEFAULT (newsequentialid()).
-    # Es mejor dejar que la base de datos lo genere.
-    # Puedes eliminar esta lógica de generación de UUID.
-    # if "requestid" not in validated_data or not validated_data.get("requestid"):
-    #     validated_data["requestid"] = uuid.uuid4()
-    # return super().create(validated_data)
+    def validate_title(self, value):
+        if not value.strip():
+            raise serializers.ValidationError("Title is required.")
+        return value
+
+    def validate_priority(self, value):
+        normalized = value.strip().lower()
+        if normalized not in self.VALID_PRIORITIES:
+            allowed = ", ".join(sorted(self.VALID_PRIORITIES))
+            raise serializers.ValidationError(f"Priority must be one of: {allowed}.")
+        return normalized
+
+    def validate(self, attrs):
+        tenant_id = self.context.get("tenant_id")
+        if not tenant_id:
+            raise serializers.ValidationError({"tenant": ["Tenant context missing."]})
+
+        flow_id = attrs.get("flowid_id")
+        status_id = attrs.get("statusid_id")
+        requester_id = attrs.get("requesterid_id")
+        assignee_id = attrs.get("assigneeid_id")
+
+        self._get_tenant_object(Flow, "flow_id", flowid=flow_id, tenantid=tenant_id)
+        status = self._get_tenant_object(
+            Status, "status_id", statusid=status_id, tenantid=tenant_id
+        )
+        if status.flowid_id != flow_id:
+            raise serializers.ValidationError(
+                {"status_id": ["Status must belong to the selected flow."]}
+            )
+
+        self._validate_user_membership("requester_id", requester_id, tenant_id)
+        if assignee_id:
+            self._validate_user_membership("assignee_id", assignee_id, tenant_id)
+        return attrs
+
+    def _get_tenant_object(self, model, public_field, **lookup):
+        try:
+            return model.objects.get(**lookup)
+        except model.DoesNotExist as exc:
+            raise serializers.ValidationError(
+                {public_field: ["Not found for this tenant."]}
+            ) from exc
+
+    def _validate_user_membership(self, public_field, user_id, tenant_id):
+        if not Membership.objects.filter(
+            userid_id=user_id, tenantid_id=tenant_id
+        ).exists():
+            raise serializers.ValidationError(
+                {public_field: ["User is not a member of this tenant."]}
+            )
 
 
 class UserSummarySerializer(serializers.ModelSerializer):

--- a/apps/rt/views.py
+++ b/apps/rt/views.py
@@ -117,11 +117,12 @@ class RequestViewSet(BaseTenantViewSet):
         if isinstance(tenant_id, str):
             tenant_id = uuid.UUID(tenant_id)
 
+        now = timezone.now()
         save_kwargs = {
             "tenantid_id": tenant_id,
             "humanid": generate_human_id(str(tenant_id)),
-            "createdat": timezone.now(),
-            "updatedat": timezone.now(),
+            "createdat": now,
+            "updatedat": now,
             "flowid_id": flow_id,
             "statusid_id": status_id,
             "requesterid_id": requester_id,

--- a/apps/rt/views.py
+++ b/apps/rt/views.py
@@ -7,7 +7,7 @@ from botocore.client import Config
 from django.conf import settings
 from django.db import connection, transaction
 from django.utils import timezone
-from rest_framework import mixins, permissions, viewsets
+from rest_framework import mixins, permissions, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import NotFound, ValidationError
 from rest_framework.permissions import IsAuthenticated
@@ -61,6 +61,43 @@ class RequestViewSet(BaseTenantViewSet):
             return RequestDetailSerializer
         return super().get_serializer_class()
 
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        context["tenant_id"] = getattr(self.request, "tenant_id", None)
+        return context
+
+    def create(self, request, *args, **kwargs):
+        if not getattr(request, "tenant_id", None):
+            return Response(
+                {
+                    "code": "tenant_required",
+                    "message": "Tenant context missing.",
+                    "details": [],
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        serializer = self.get_serializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(
+                {
+                    "code": "validation_error",
+                    "message": "Invalid request payload.",
+                    "details": format_validation_details(serializer.errors),
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        rt_request = self.perform_create(serializer)
+        response_serializer = self.get_serializer(rt_request)
+        headers = self.get_success_headers(response_serializer.data)
+        return Response(
+            response_serializer.data,
+            status=status.HTTP_201_CREATED,
+            headers=headers,
+        )
+
+    @transaction.atomic
     def perform_create(self, serializer):
         validated_data = serializer.validated_data
 
@@ -91,7 +128,30 @@ class RequestViewSet(BaseTenantViewSet):
         }
         if assignee_id:
             save_kwargs["assigneeid_id"] = assignee_id
-        serializer.save(**save_kwargs)
+        rt_request = serializer.save(**save_kwargs)
+        Activity.objects.create(
+            activityid=uuid.uuid4(),
+            tenantid=rt_request.tenantid,
+            requestid=rt_request,
+            actorid=rt_request.requesterid,
+            type="request.created",
+            payload=json.dumps(
+                {
+                    "human_id": rt_request.humanid,
+                    "title": rt_request.title,
+                    "flow_id": str(rt_request.flowid_id),
+                    "status_id": str(rt_request.statusid_id),
+                    "requester_id": str(rt_request.requesterid_id),
+                    "assignee_id": (
+                        str(rt_request.assigneeid_id)
+                        if rt_request.assigneeid_id
+                        else None
+                    ),
+                }
+            ),
+            createdat=save_kwargs["createdat"],
+        )
+        return rt_request
 
     @action(detail=True, methods=["get"])
     def activity(self, request, pk=None):
@@ -421,6 +481,25 @@ class SearchView(APIView):
                 status=400,
             )
         return Response(results)
+
+
+def format_validation_details(errors):
+    details = []
+
+    def walk(value, field):
+        if isinstance(value, dict):
+            for key, child in value.items():
+                child_field = f"{field}.{key}" if field else str(key)
+                walk(child, child_field)
+            return
+        if isinstance(value, list):
+            for child in value:
+                walk(child, field)
+            return
+        details.append({"field": field, "message": str(value)})
+
+    walk(errors, "")
+    return details
 
 
 def build_storage_url(object_key):

--- a/docs/plans/sprint-2/api-full-request-lifecycle-execplan.md
+++ b/docs/plans/sprint-2/api-full-request-lifecycle-execplan.md
@@ -6,15 +6,34 @@ This plan completes the backend side of the request lifecycle. After the change,
 
 ## Repository orientation
 
-This plan applies to `rt-api`. Relevant areas: `apps/rt/models.py`, `apps/rt/serializers/`, `apps/rt/views/`, `apps/rt/services/`, `rt_api/urls.py`, OpenAPI files, `AGENTS.md`, and `.agent/PLANS.md`.
+This plan applies to `rt-api`. Relevant areas:
+
+- `apps/rt/models.py`: unmanaged SQL Server models for `Tenant`, `User`, `Flow`, `Status`, `Request`, `Comment`, `Attachment`, `Activity`, and workflow tables.
+- `apps/rt/serializers.py`: current request, detail, comment, upload, activity, and search serializers.
+- `apps/rt/views.py`: `RequestViewSet`, nested comments/attachments, uploads, search, and current `generate_human_id` helper.
+- `apps/rt/search.py`: SQL Server FTS search service.
+- `rt_api/urls.py`: DRF router for `/api/requests/`, nested request routes, auth, uploads, search, schema, and Swagger UI.
+- `tests/`: pytest coverage for auth/docs, health, comments, uploads, search, and request detail.
+- `AGENTS.md` and `.agent/PLANS.md`: contributor and ExecPlan rules.
+
+There is no checked-in `openapi-rt-with-examples.yaml` or other OpenAPI source file at the time this plan was updated. The repository currently exposes generated OpenAPI through drf-spectacular at `GET /api/schema` and Swagger UI at `GET /api/docs`.
 
 ## Current behavior
 
-Sprint 1 has JWT auth, tenant enforcement, request models, comments, grouped uploads, search, and dashboard usage. Some APIs may still expose internal Django field names like `flowid_id`.
+Sprint 1 has JWT auth, tenant enforcement, request models, comments, grouped uploads, search, and dashboard usage. Day 1-2 request detail work added:
+
+- `GET /api/requests/{id}/detail/` with request, comments, attachments, and activity.
+- `GET /api/requests/{id}/activities/` as an alias to activity timeline.
+- Trailing-slash aliases for nested comments and attachments.
+- `RequestDetailSerializer` with public fields such as `request_id`, `human_id`, `flow_id`, `status_id`, `requester_id`, `assignee_id`, `due_at`, `created_at`, and `updated_at`.
+
+Request creation is not yet clean enough for Day 3-4. `RequestSerializer` still accepts and returns internal Django field names: `requestid`, `humanid`, `flowid_id`, `statusid_id`, `requesterid_id`, `assigneeid_id`, `dueat`, `createdat`, and `updatedat`. `RequestViewSet.perform_create` generates `HumanId` and assigns tenant, but it does not yet validate flow/status/requester/assignee tenant ownership, does not validate that `status_id` belongs to `flow_id`, and does not create `Activity` type `request.created`.
 
 ## Desired behavior
 
 Expose clean public JSON fields: `request_id`, `human_id`, `flow_id`, `status_id`, `requester_id`, `assignee_id`, `created_at`, and `updated_at`. Add request detail, create flow hardening, transitions, dashboard summary, and notification baseline.
+
+For Day 3-4, `POST /api/requests/` must accept only public field names, enforce tenant-scoped IDs, validate the flow/status relationship, generate `HumanId`, create an auditable `Activity`, and return the same clean request shape used by detail reads.
 
 ## Scope
 
@@ -32,7 +51,54 @@ Add or harden `GET /api/requests/{id}/detail/` or equivalent detail response. In
 
 ### Milestone 3: Create request full API flow
 
-Validate flow/status relationship, generate `HumanId`, assign tenant, create `Activity` type `request.created`, and return clean JSON.
+Day 3-4 target branch: `feat/api-create-request-flow`.
+
+Update only API code and tests needed for robust request creation. The next implementation pass must cover:
+
+1. Clean public API fields.
+   - Edit `apps/rt/serializers.py`.
+   - Add or replace the create/list request serializer so request writes use `flow_id`, `status_id`, `requester_id`, optional `assignee_id`, optional `due_at`, and optional `custom_fields`.
+   - Stop requiring client payloads to send `flowid_id`, `statusid_id`, `requesterid_id`, `assigneeid_id`, or `dueat`.
+   - Return public response fields: `request_id`, `human_id`, `title`, `description`, `priority`, `flow_id`, `status_id`, `requester_id`, `assignee_id`, `custom_fields`, `due_at`, `created_at`, and `updated_at`.
+   - Preserve existing `RequestDetailSerializer` shape for `GET /api/requests/{id}/` and `/detail/`.
+
+2. Request creation validation.
+   - Validate `title` is present and non-blank.
+   - Validate `priority` is present and one of the accepted local values: `low`, `normal`, `high`, or `urgent`.
+   - Validate `flow_id`, `status_id`, and `requester_id` are valid UUIDs.
+   - Validate optional `assignee_id` is either null/omitted or a valid UUID.
+   - Validate `flow_id`, `status_id`, `requester_id`, and optional `assignee_id` all belong to the active `request.tenant_id`.
+   - Validate `status_id` belongs to the provided `flow_id`.
+   - Return JSON validation errors with `code`, `message`, and `details[]`; never return SQL Server integrity errors or Django stack traces for bad input.
+
+3. HumanId generation.
+   - Keep `generate_human_id` behavior using `dbo.IdSequence` with `UPDLOCK` and `HOLDLOCK`.
+   - Ensure creation remains atomic so `Request` insert, `HumanId` sequence update/insert, and `Activity` creation succeed or fail together.
+   - Verify generated IDs keep the current format `RT-{year}-{sequence:06d}`.
+
+4. Tenant enforcement.
+   - Continue deriving tenant from `X-Tenant` middleware as `request.tenant_id`.
+   - Ignore any tenant field in client payload if provided; clients must not be able to choose another tenant.
+   - All lookup queries during create must filter by `tenantid=request.tenant_id`.
+   - Negative tests must prove cross-tenant `flow_id`, `status_id`, `requester_id`, or `assignee_id` cannot create a request.
+
+5. Activity creation.
+   - Create one `Activity` row with type `request.created`.
+   - Set `tenantid` to the request tenant, `requestid` to the created request, `actorid` to the requester until auth-user to `dbo.User` mapping exists, and `createdat` to the same creation timestamp.
+   - Include a compact JSON payload with at least `human_id`, `title`, `flow_id`, `status_id`, `requester_id`, and `assignee_id`.
+   - Add tests that assert exactly one `request.created` activity is attempted on successful create.
+
+6. OpenAPI/schema handling.
+   - Because no static OpenAPI source file currently exists, update serializer names and drf-spectacular annotations only as needed so `GET /api/schema` reflects public create fields.
+   - If a static OpenAPI source file is later added, update it before code implementation per `AGENTS.md`.
+
+Implementation files expected for this milestone:
+
+- `apps/rt/serializers.py`
+- `apps/rt/views.py`
+- optional new `apps/rt/services/request_service.py` if create logic becomes too large for `RequestViewSet.perform_create`
+- `tests/test_request_create.py`
+- optional updates to `tests/test_request_detail.py` if shared serializers change
 
 ### Milestone 4: Workflow transitions
 
@@ -48,29 +114,223 @@ Add `apps/rt/services/notification_service.py`. Send Mailhog-visible emails for 
 
 ## Tests and verification
 
-Run `poetry run pytest`. Manually verify Postman create request, request detail, transition/close, dashboard summary, and Mailhog email.
+### Automated checks for every milestone
+
+Run these from repository root:
+
+```bash
+poetry run python manage.py check
+poetry run pytest -q
+poetry run ruff check .
+poetry run black . --check
+poetry run isort . --check --diff
+git diff --check
+```
+
+### Day 3-4 pytest coverage
+
+Add `tests/test_request_create.py` with tests for:
+
+- `RequestSerializer` or create serializer accepts public fields: `flow_id`, `status_id`, `requester_id`, optional `assignee_id`, `due_at`, and `custom_fields`.
+- Serializer rejects legacy/internal-only payload names for create, or maps them only if explicit backward compatibility is intentionally chosen and documented in the Decision Log.
+- `RequestViewSet.perform_create` or request service saves:
+  - `tenantid_id` from `request.tenant_id`
+  - generated `humanid`
+  - `createdat` and `updatedat`
+  - `flowid_id`, `statusid_id`, `requesterid_id`, optional `assigneeid_id`
+- `generate_human_id` keeps `RT-{year}-{sequence:06d}` and updates/inserts `dbo.IdSequence`.
+- Successful create attempts `Activity.objects.create(...)` with `type="request.created"`.
+- Status from a different flow returns validation error.
+- Flow/status/requester/assignee from another tenant returns validation error.
+- Missing tenant context returns a JSON error, not an insert attempt.
+- Invalid UUID input returns 400 validation error, not 500.
+
+### Day 3-4 Postman smoke verification
+
+Environment:
+
+```text
+base_url=http://localhost:8000
+tenant_code=ACME
+TOKEN=<JWT access token>
+flow_id=<GUID from ACME dbo.Flow>
+status_id=<GUID from ACME dbo.Status belonging to flow_id>
+requester_id=<GUID from ACME dbo.User>
+assignee_id=<GUID from ACME dbo.User or null>
+```
+
+Headers for all protected calls:
+
+```text
+Authorization: Bearer {{TOKEN}}
+X-Tenant: {{tenant_code}}
+Content-Type: application/json
+```
+
+1. Create request with assignee:
+
+```http
+POST {{base_url}}/api/requests/
+```
+
+```json
+{
+  "title": "Sprint 2 Postman create smoke",
+  "description": "Created from Postman during Sprint 2 Day 3-4.",
+  "flow_id": "{{flow_id}}",
+  "status_id": "{{status_id}}",
+  "requester_id": "{{requester_id}}",
+  "assignee_id": "{{assignee_id}}",
+  "priority": "normal",
+  "due_at": "2026-05-29T17:00:00Z",
+  "custom_fields": "{\"source\":\"postman\"}"
+}
+```
+
+Expected:
+
+```text
+201 Created
+response has request_id, human_id, title, flow_id, status_id, requester_id,
+assignee_id, priority, due_at, created_at, updated_at
+response does not require or expose flowid_id/statusid_id/requesterid_id/assigneeid_id
+human_id matches RT-2026-000001 style
+```
+
+Save `request_id` from the response.
+
+2. Verify detail:
+
+```http
+GET {{base_url}}/api/requests/{{request_id}}/detail/
+```
+
+Expected:
+
+```text
+200 OK
+request.human_id matches create response
+request.flow_id/status_id/requester_id/assignee_id match create payload
+comments, attachments, and activity arrays are present
+activity includes request.created
+```
+
+3. Verify activities alias:
+
+```http
+GET {{base_url}}/api/requests/{{request_id}}/activities/
+```
+
+Expected:
+
+```text
+200 OK
+at least one item has type=request.created
+```
+
+4. Negative: status from another flow:
+
+```http
+POST {{base_url}}/api/requests/
+```
+
+Use a valid `flow_id` and a `status_id` that belongs to another flow.
+
+Expected:
+
+```text
+400 Bad Request
+JSON error has code, message, details[]
+details identify status_id or flow/status mismatch
+```
+
+5. Negative: cross-tenant lookup:
+
+Use `X-Tenant: ACME` with a `flow_id`, `status_id`, requester, or assignee from another tenant.
+
+Expected:
+
+```text
+400 Bad Request or 404 Not Found with JSON error
+no request is created
+no Activity is created
+```
+
+6. Negative: invalid UUID:
+
+```json
+{
+  "title": "Bad UUID smoke",
+  "description": "Should fail cleanly.",
+  "flow_id": "not-a-guid",
+  "status_id": "{{status_id}}",
+  "requester_id": "{{requester_id}}",
+  "priority": "normal"
+}
+```
+
+Expected:
+
+```text
+400 Bad Request
+JSON error, no stack trace
+```
 
 ## Acceptance criteria
 
-Public API no longer requires internal fields; request detail supports web; transitions work; dashboard summary exists; notifications work locally; OpenAPI is updated; tests pass.
+Sprint-level acceptance: public API no longer requires internal fields; request detail supports web; transitions work; dashboard summary exists; notifications work locally; OpenAPI/schema is updated; tests pass.
+
+Day 3-4 acceptance:
+
+- `POST /api/requests/` accepts clean public JSON field names.
+- `POST /api/requests/` returns clean public JSON field names.
+- Legacy internal create fields are not required by frontend or Postman.
+- Tenant is always derived from `X-Tenant`; tenant payload values cannot override it.
+- Flow, status, requester, and assignee are tenant-scoped.
+- Status must belong to the selected flow.
+- `HumanId` is generated server-side with the existing sequence table.
+- Successful create writes `Activity` type `request.created`.
+- Validation failures return JSON errors with no SQL Server or Django stack traces.
+- Pytest and Postman steps in this plan pass.
 
 ## Progress
 
 - [ ] Milestone 1 completed.
-- [ ] Milestone 2 completed.
-- [ ] Milestone 3 completed.
+- [x] Milestone 2 completed.
+- [x] Milestone 3 completed.
+  - [x] Postman regression fixed: requester/assignee tenant checks use `Membership`, not `User.tenantid`.
 - [ ] Milestone 4 completed.
 - [ ] Milestone 5 completed.
 - [ ] Milestone 6 completed.
 
 ## Surprises & Discoveries
 
-Record findings here.
+- No checked-in OpenAPI source file was found during Day 3-4 planning; current schema is generated by drf-spectacular at `/api/schema`.
+- There is no `apps/rt/services/` package yet. Create request logic currently lives in `RequestViewSet.perform_create`.
+- Day 1-2 request detail code is present on the current branch, including `RequestDetailSerializer` and `/api/requests/{id}/detail/`.
+- Before Milestone 3, create request still used internal serializer fields and did not create `request.created` activity.
+- Milestone 3 was small enough to keep in `RequestSerializer` and `RequestViewSet`; no new service module was needed.
+- Existing unit-test style avoids live SQL Server calls by monkeypatching model managers and `generate_human_id`.
+- Postman found a real create-request bug: `User` has no `tenantid` field, so validating `requester_id` or `assignee_id` with `User.objects.get(..., tenantid=...)` raises `FieldError` and returns 500.
+- Tenant membership for users is represented by `Membership.userid` and `Membership.tenantid`; Django lookup fields are `userid_id` and `tenantid_id`.
 
 ## Decision Log
 
-Record decisions here.
+- Keep `GET /api/requests/{id}/detail/` for the web request detail page and focus Day 3-4 on `POST /api/requests/`.
+- Treat drf-spectacular generated schema as the current OpenAPI surface until a static OpenAPI source file is added.
+- Use requester as `Activity.actorid` for request creation until auth-user to `dbo.User` mapping is introduced.
+- Accept create-request priorities `low`, `normal`, `high`, and `urgent`, normalizing input to lowercase.
+- Keep backward-incompatible internal create field names out of the public create contract; tests assert `flowid_id`, `statusid_id`, and related names are not accepted as the required API fields.
+- Validate `requester_id` and optional `assignee_id` against `Membership.objects.filter(userid_id=<user_id>, tenantid_id=<tenant_id>).exists()` instead of filtering `User` by tenant.
+- Return serializer `ValidationError` on public fields `requester_id` and `assignee_id` when a user is not a member of the active tenant.
 
 ## Outcomes & Retrospective
 
-Complete after merge.
+Milestone 3 complete on `feat/api-create-request-flow`:
+
+- `POST /api/requests/` now uses public request fields and returns public response fields.
+- Create validation enforces tenant-scoped `flow_id`, `status_id`, `requester_id`, optional `assignee_id`, and status-to-flow ownership.
+- User tenant enforcement now checks `Membership`, preventing the SQL/Django `FieldError` seen in Postman.
+- Request creation remains server-owned for `tenantid`, `HumanId`, `createdat`, and `updatedat`.
+- Successful create writes `Activity` type `request.created`.
+- Focused and full pytest verification passed locally.

--- a/docs/plans/sprint-2/api-full-request-lifecycle-execplan.md
+++ b/docs/plans/sprint-2/api-full-request-lifecycle-execplan.md
@@ -313,6 +313,7 @@ Day 3-4 acceptance:
 - Existing unit-test style avoids live SQL Server calls by monkeypatching model managers and `generate_human_id`.
 - Postman found a real create-request bug: `User` has no `tenantid` field, so validating `requester_id` or `assignee_id` with `User.objects.get(..., tenantid=...)` raises `FieldError` and returns 500.
 - Tenant membership for users is represented by `Membership.userid` and `Membership.tenantid`; Django lookup fields are `userid_id` and `tenantid_id`.
+- GitHub Actions found a timestamp determinism bug in `RequestViewSet.perform_create`: separate `timezone.now()` calls for `createdat` and `updatedat` can differ by microseconds and make tests flaky.
 
 ## Decision Log
 
@@ -323,6 +324,7 @@ Day 3-4 acceptance:
 - Keep backward-incompatible internal create field names out of the public create contract; tests assert `flowid_id`, `statusid_id`, and related names are not accepted as the required API fields.
 - Validate `requester_id` and optional `assignee_id` against `Membership.objects.filter(userid_id=<user_id>, tenantid_id=<tenant_id>).exists()` instead of filtering `User` by tenant.
 - Return serializer `ValidationError` on public fields `requester_id` and `assignee_id` when a user is not a member of the active tenant.
+- Compute the request creation timestamp once and reuse it for both `createdat` and `updatedat`.
 
 ## Outcomes & Retrospective
 

--- a/tests/test_request_create.py
+++ b/tests/test_request_create.py
@@ -1,0 +1,443 @@
+import json
+import uuid
+from types import SimpleNamespace
+
+from django.core.exceptions import FieldError
+from django.utils import timezone
+
+from apps.rt.models import Flow, Membership, Request, Status, Tenant, User
+from apps.rt.serializers import RequestSerializer
+from apps.rt.views import RequestViewSet
+
+
+def create_payload(flow_id, status_id, requester_id, assignee_id=None):
+    payload = {
+        "title": "Sprint 2 create request",
+        "description": "Created by API test.",
+        "flow_id": str(flow_id),
+        "status_id": str(status_id),
+        "requester_id": str(requester_id),
+        "priority": "NORMAL",
+        "due_at": "2026-05-29T17:00:00Z",
+        "custom_fields": '{"source":"pytest"}',
+    }
+    if assignee_id is not None:
+        payload["assignee_id"] = str(assignee_id)
+    return payload
+
+
+class FakeExistsQuerySet:
+    def __init__(self, exists):
+        self._exists = exists
+
+    def exists(self):
+        return self._exists
+
+
+def patch_create_lookups(
+    monkeypatch,
+    tenant,
+    flow_id,
+    requester_id=None,
+    assignee_id=None,
+    status_flow_id=None,
+    requester_in_tenant=True,
+    assignee_in_tenant=True,
+):
+    status_flow_id = status_flow_id or flow_id
+    requester_id = requester_id or uuid.uuid4()
+    assignee_id = assignee_id or uuid.uuid4()
+
+    def flow_get(**kwargs):
+        assert kwargs == {"flowid": flow_id, "tenantid": tenant.tenantid}
+        return Flow(flowid=flow_id, tenantid=tenant, name="IT Support")
+
+    def status_get(**kwargs):
+        return Status(
+            statusid=kwargs["statusid"],
+            tenantid=tenant,
+            flowid=Flow(flowid=status_flow_id, tenantid=tenant, name="IT Support"),
+            name="Open",
+            category="open",
+            isterminal=False,
+        )
+
+    def membership_filter(**kwargs):
+        assert kwargs["tenantid_id"] == tenant.tenantid
+        user_id = kwargs["userid_id"]
+        if user_id == requester_id:
+            return FakeExistsQuerySet(requester_in_tenant)
+        if user_id == assignee_id:
+            return FakeExistsQuerySet(assignee_in_tenant)
+        return FakeExistsQuerySet(True)
+
+    monkeypatch.setattr(Flow.objects, "get", flow_get)
+    monkeypatch.setattr(Status.objects, "get", status_get)
+    monkeypatch.setattr(Membership.objects, "filter", membership_filter)
+
+
+def test_request_serializer_accepts_public_create_fields(monkeypatch):
+    tenant = Tenant(tenantid=uuid.uuid4())
+    flow_id = uuid.uuid4()
+    status_id = uuid.uuid4()
+    requester_id = uuid.uuid4()
+    assignee_id = uuid.uuid4()
+    patch_create_lookups(
+        monkeypatch,
+        tenant,
+        flow_id,
+        requester_id=requester_id,
+        assignee_id=assignee_id,
+    )
+
+    serializer = RequestSerializer(
+        data=create_payload(flow_id, status_id, requester_id, assignee_id),
+        context={"tenant_id": tenant.tenantid},
+    )
+
+    assert serializer.is_valid(), serializer.errors
+    assert serializer.validated_data["flowid_id"] == flow_id
+    assert serializer.validated_data["statusid_id"] == status_id
+    assert serializer.validated_data["requesterid_id"] == requester_id
+    assert serializer.validated_data["assigneeid_id"] == assignee_id
+    assert serializer.validated_data["priority"] == "normal"
+    assert serializer.validated_data["customfields"] == '{"source":"pytest"}'
+
+
+def test_request_serializer_rejects_requester_not_in_tenant(monkeypatch):
+    tenant = Tenant(tenantid=uuid.uuid4())
+    flow_id = uuid.uuid4()
+    requester_id = uuid.uuid4()
+    patch_create_lookups(
+        monkeypatch,
+        tenant,
+        flow_id,
+        requester_id=requester_id,
+        requester_in_tenant=False,
+    )
+
+    serializer = RequestSerializer(
+        data=create_payload(flow_id, uuid.uuid4(), requester_id),
+        context={"tenant_id": tenant.tenantid},
+    )
+
+    assert not serializer.is_valid()
+    assert (
+        serializer.errors["requester_id"][0] == "User is not a member of this tenant."
+    )
+
+
+def test_request_serializer_rejects_assignee_not_in_tenant(monkeypatch):
+    tenant = Tenant(tenantid=uuid.uuid4())
+    flow_id = uuid.uuid4()
+    requester_id = uuid.uuid4()
+    assignee_id = uuid.uuid4()
+    patch_create_lookups(
+        monkeypatch,
+        tenant,
+        flow_id,
+        requester_id=requester_id,
+        assignee_id=assignee_id,
+        assignee_in_tenant=False,
+    )
+
+    serializer = RequestSerializer(
+        data=create_payload(flow_id, uuid.uuid4(), requester_id, assignee_id),
+        context={"tenant_id": tenant.tenantid},
+    )
+
+    assert not serializer.is_valid()
+    assert serializer.errors["assignee_id"][0] == "User is not a member of this tenant."
+
+
+def test_request_serializer_uses_public_response_fields():
+    tenant = Tenant(tenantid=uuid.uuid4())
+    flow = Flow(flowid=uuid.uuid4(), tenantid=tenant, name="IT Support")
+    status = Status(
+        statusid=uuid.uuid4(),
+        tenantid=tenant,
+        flowid=flow,
+        name="Open",
+        category="open",
+        isterminal=False,
+    )
+    requester = User(userid=uuid.uuid4(), email="requester@example.com")
+    assignee = User(userid=uuid.uuid4(), email="assignee@example.com")
+    now = timezone.now()
+    rt_request = Request(
+        requestid=uuid.uuid4(),
+        tenantid=tenant,
+        humanid="RT-2026-000123",
+        title="Public response",
+        description="Clean public fields.",
+        flowid=flow,
+        statusid=status,
+        requesterid=requester,
+        assigneeid=assignee,
+        priority="normal",
+        customfields='{"source":"pytest"}',
+        dueat=now,
+        createdat=now,
+        updatedat=now,
+    )
+
+    data = RequestSerializer(rt_request).data
+
+    assert data["request_id"] == str(rt_request.requestid)
+    assert data["human_id"] == "RT-2026-000123"
+    assert data["flow_id"] == str(flow.flowid)
+    assert data["status_id"] == str(status.statusid)
+    assert data["requester_id"] == str(requester.userid)
+    assert data["assignee_id"] == str(assignee.userid)
+    assert data["custom_fields"] == '{"source":"pytest"}'
+    assert data["due_at"]
+    assert "flowid_id" not in data
+    assert "statusid_id" not in data
+    assert "requesterid_id" not in data
+    assert "assigneeid_id" not in data
+
+
+def test_request_serializer_rejects_internal_create_fields(monkeypatch):
+    tenant = Tenant(tenantid=uuid.uuid4())
+    flow_id = uuid.uuid4()
+    status_id = uuid.uuid4()
+    requester_id = uuid.uuid4()
+    patch_create_lookups(monkeypatch, tenant, flow_id, requester_id=requester_id)
+
+    serializer = RequestSerializer(
+        data={
+            "title": "Legacy payload",
+            "description": "Should not be accepted.",
+            "flowid_id": str(flow_id),
+            "statusid_id": str(status_id),
+            "requesterid_id": str(requester_id),
+            "priority": "normal",
+        },
+        context={"tenant_id": tenant.tenantid},
+    )
+
+    assert not serializer.is_valid()
+    assert "flow_id" in serializer.errors
+    assert "status_id" in serializer.errors
+    assert "requester_id" in serializer.errors
+
+
+def test_request_serializer_rejects_status_from_another_flow(monkeypatch):
+    tenant = Tenant(tenantid=uuid.uuid4())
+    flow_id = uuid.uuid4()
+    other_flow_id = uuid.uuid4()
+    patch_create_lookups(monkeypatch, tenant, flow_id, status_flow_id=other_flow_id)
+
+    serializer = RequestSerializer(
+        data=create_payload(flow_id, uuid.uuid4(), uuid.uuid4()),
+        context={"tenant_id": tenant.tenantid},
+    )
+
+    assert not serializer.is_valid()
+    assert (
+        serializer.errors["status_id"][0] == "Status must belong to the selected flow."
+    )
+
+
+def test_request_serializer_rejects_cross_tenant_lookup(monkeypatch):
+    tenant = Tenant(tenantid=uuid.uuid4())
+
+    def flow_get(**kwargs):
+        raise Flow.DoesNotExist
+
+    monkeypatch.setattr(Flow.objects, "get", flow_get)
+
+    serializer = RequestSerializer(
+        data=create_payload(uuid.uuid4(), uuid.uuid4(), uuid.uuid4()),
+        context={"tenant_id": tenant.tenantid},
+    )
+
+    assert not serializer.is_valid()
+    assert serializer.errors["flow_id"][0] == "Not found for this tenant."
+
+
+def test_request_create_returns_json_validation_shape_for_bad_uuid():
+    tenant_id = uuid.uuid4()
+    request = SimpleNamespace(
+        data={
+            "title": "Bad UUID",
+            "description": "Should fail cleanly.",
+            "flow_id": "not-a-guid",
+            "status_id": str(uuid.uuid4()),
+            "requester_id": str(uuid.uuid4()),
+            "priority": "normal",
+        },
+        tenant_id=tenant_id,
+    )
+    view = RequestViewSet()
+    view.request = request
+    view.action = "create"
+    view.format_kwarg = None
+
+    response = view.create(request)
+
+    assert response.status_code == 400
+    assert response.data["code"] == "validation_error"
+    assert response.data["message"] == "Invalid request payload."
+    assert response.data["details"][0]["field"] == "flow_id"
+
+
+def test_request_create_post_does_not_raise_field_error_for_user_tenant_validation(
+    monkeypatch,
+):
+    tenant = Tenant(tenantid=uuid.uuid4())
+    flow_id = uuid.uuid4()
+    status_id = uuid.uuid4()
+    requester_id = uuid.uuid4()
+    assignee_id = uuid.uuid4()
+    patch_create_lookups(
+        monkeypatch,
+        tenant,
+        flow_id,
+        requester_id=requester_id,
+        assignee_id=assignee_id,
+    )
+    monkeypatch.setattr(
+        User.objects,
+        "get",
+        lambda **kwargs: (_ for _ in ()).throw(
+            FieldError("Cannot resolve keyword 'tenantid' into field.")
+        ),
+    )
+    now = timezone.now()
+    rt_request = Request(
+        requestid=uuid.uuid4(),
+        tenantid=tenant,
+        humanid="RT-2026-000555",
+        title="No FieldError",
+        description="Membership validation only.",
+        flowid=Flow(flowid=flow_id, tenantid=tenant, name="IT Support"),
+        statusid=Status(
+            statusid=status_id,
+            tenantid=tenant,
+            flowid=Flow(flowid=flow_id, tenantid=tenant),
+            name="Open",
+            category="open",
+            isterminal=False,
+        ),
+        requesterid=User(userid=requester_id, email="requester@example.com"),
+        assigneeid=User(userid=assignee_id, email="assignee@example.com"),
+        priority="normal",
+        createdat=now,
+        updatedat=now,
+    )
+    request = SimpleNamespace(
+        data=create_payload(flow_id, status_id, requester_id, assignee_id),
+        tenant_id=tenant.tenantid,
+    )
+    view = RequestViewSet()
+    view.request = request
+    view.action = "create"
+    view.format_kwarg = None
+    view.perform_create = lambda serializer: rt_request
+
+    response = view.create(request)
+
+    assert response.status_code == 201
+    assert response.data["request_id"] == str(rt_request.requestid)
+
+
+def test_request_create_missing_tenant_returns_json_error():
+    request = SimpleNamespace(data={}, tenant_id=None)
+    view = RequestViewSet()
+    view.request = request
+    view.action = "create"
+    view.format_kwarg = None
+
+    response = view.create(request)
+
+    assert response.status_code == 400
+    assert response.data == {
+        "code": "tenant_required",
+        "message": "Tenant context missing.",
+        "details": [],
+    }
+
+
+def test_request_perform_create_generates_human_id_and_activity(monkeypatch):
+    tenant_id = uuid.uuid4()
+    flow_id = uuid.uuid4()
+    status_id = uuid.uuid4()
+    requester_id = uuid.uuid4()
+    assignee_id = uuid.uuid4()
+    tenant = Tenant(tenantid=tenant_id)
+    requester = User(userid=requester_id, email="requester@example.com")
+    assignee = User(userid=assignee_id, email="assignee@example.com")
+    saved_kwargs = {}
+    created_activities = []
+
+    class FakeSerializer:
+        validated_data = {
+            "title": "Created request",
+            "description": "Created by perform_create.",
+            "flowid_id": flow_id,
+            "statusid_id": status_id,
+            "requesterid_id": requester_id,
+            "assigneeid_id": assignee_id,
+            "priority": "normal",
+        }
+
+        def save(self, **kwargs):
+            saved_kwargs.update(kwargs)
+            return Request(
+                requestid=uuid.uuid4(),
+                tenantid=tenant,
+                humanid=kwargs["humanid"],
+                title=self.validated_data["title"],
+                description=self.validated_data["description"],
+                flowid=Flow(flowid=flow_id, tenantid=tenant, name="IT Support"),
+                statusid=Status(
+                    statusid=status_id,
+                    tenantid=tenant,
+                    flowid=Flow(flowid=flow_id, tenantid=tenant),
+                    name="Open",
+                    category="open",
+                    isterminal=False,
+                ),
+                requesterid=requester,
+                assigneeid=assignee,
+                priority=self.validated_data["priority"],
+                createdat=kwargs["createdat"],
+                updatedat=kwargs["updatedat"],
+            )
+
+    monkeypatch.setattr(
+        "apps.rt.views.generate_human_id", lambda tenant: "RT-2026-000777"
+    )
+    monkeypatch.setattr(
+        "apps.rt.views.Activity.objects.create",
+        lambda **kwargs: created_activities.append(kwargs),
+    )
+
+    view = RequestViewSet()
+    view.request = SimpleNamespace(tenant_id=tenant_id)
+    perform_create = RequestViewSet.perform_create.__wrapped__
+
+    rt_request = perform_create(view, FakeSerializer())
+
+    assert rt_request.humanid == "RT-2026-000777"
+    assert saved_kwargs["tenantid_id"] == tenant_id
+    assert saved_kwargs["flowid_id"] == flow_id
+    assert saved_kwargs["statusid_id"] == status_id
+    assert saved_kwargs["requesterid_id"] == requester_id
+    assert saved_kwargs["assigneeid_id"] == assignee_id
+    assert saved_kwargs["createdat"] == saved_kwargs["updatedat"]
+    assert len(created_activities) == 1
+    activity = created_activities[0]
+    assert activity["type"] == "request.created"
+    assert activity["tenantid"] == tenant
+    assert activity["requestid"] == rt_request
+    assert activity["actorid"] == requester
+    assert json.loads(activity["payload"]) == {
+        "human_id": "RT-2026-000777",
+        "title": "Created request",
+        "flow_id": str(flow_id),
+        "status_id": str(status_id),
+        "requester_id": str(requester_id),
+        "assignee_id": str(assignee_id),
+    }


### PR DESCRIPTION
## Summary
- add public create request fields and public response names
- validate flow/status/requester/assignee against tenant context
- validate requester and assignee through Membership to avoid User.tenantid FieldError
- generate HumanId and create request.created activity on successful create
- add request create regression tests and update the Sprint 2 ExecPlan

## Validation
- poetry run python manage.py check
- poetry run pytest -q
- poetry run ruff check .
- poetry run black . --check
- poetry run isort . --check --diff
- git diff --check