### PR TITLE
feat(requests): add workflow transitions

### DIFF
--- a/apps/rt/serializers.py
+++ b/apps/rt/serializers.py
@@ -8,6 +8,7 @@ from .models import (
     Membership,
     Request,
     Status,
+    Transition,
     User,
 )
 
@@ -154,6 +155,26 @@ class UserLookupSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = ["user_id", "display_name", "email"]
+
+
+class TransitionLookupSerializer(serializers.ModelSerializer):
+    transition_id = serializers.UUIDField(source="transitionid", read_only=True)
+    from_status_id = serializers.UUIDField(source="fromstatusid_id", read_only=True)
+    to_status_id = serializers.UUIDField(source="tostatusid_id", read_only=True)
+    to_status = StatusLookupSerializer(source="tostatusid", read_only=True)
+
+    class Meta:
+        model = Transition
+        fields = ["transition_id", "from_status_id", "to_status_id", "to_status"]
+
+
+class RequestTransitionSerializer(serializers.Serializer):
+    transition_id = serializers.UUIDField()
+    comment = serializers.CharField(required=False, allow_blank=True)
+
+
+class RequestCloseReopenSerializer(serializers.Serializer):
+    comment = serializers.CharField(required=False, allow_blank=True)
 
 
 class RequestDetailSerializer(serializers.ModelSerializer):

--- a/apps/rt/views.py
+++ b/apps/rt/views.py
@@ -24,6 +24,7 @@ from .models import (
     Membership,
     Request,
     Status,
+    Transition,
     User,
 )
 from .search import SearchValidationError, search_requests
@@ -35,10 +36,13 @@ from .serializers import (
     AttachmentSerializer,
     CommentSerializer,
     FlowLookupSerializer,
+    RequestCloseReopenSerializer,
     RequestDetailSerializer,
     RequestSerializer,
+    RequestTransitionSerializer,
     SearchQuerySerializer,
     StatusLookupSerializer,
+    TransitionLookupSerializer,
     UserLookupSerializer,
 )
 
@@ -205,6 +209,109 @@ class RequestViewSet(BaseTenantViewSet):
             tenantid=tenant_id, requestid=rt_request.requestid
         ).order_by("-createdat")
         return Response(ActivitySerializer(items, many=True).data)
+
+    @extend_schema(
+        responses=TransitionLookupSerializer(many=True),
+        description="List workflow transitions available from the request current status.",
+    )
+    @action(detail=True, methods=["get"], url_path="available-transitions")
+    def available_transitions(self, request, pk=None):
+        rt_request = self.get_object()
+        transitions = get_available_transitions(rt_request)
+        return Response(TransitionLookupSerializer(transitions, many=True).data)
+
+    @extend_schema(
+        request=RequestTransitionSerializer,
+        responses=RequestSerializer,
+        description="Apply a workflow transition to a tenant-scoped request.",
+    )
+    @action(detail=True, methods=["post"], url_path="transition")
+    def transition(self, request, pk=None):
+        serializer = RequestTransitionSerializer(data=request.data)
+        if not serializer.is_valid():
+            return validation_error_response(serializer.errors)
+
+        rt_request = self.get_object()
+        try:
+            transition = get_available_transitions(rt_request).get(
+                transitionid=serializer.validated_data["transition_id"]
+            )
+        except Transition.DoesNotExist:
+            return Response(
+                {
+                    "code": "invalid_transition",
+                    "message": "Transition is not available for this request.",
+                    "details": [
+                        {
+                            "field": "transition_id",
+                            "message": "Not available from current status.",
+                        }
+                    ],
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        updated_request = apply_transition(
+            rt_request=rt_request,
+            transition=transition,
+            action_type="request.transitioned",
+            comment=serializer.validated_data.get("comment") or "",
+        )
+        return Response(RequestSerializer(updated_request).data)
+
+    @extend_schema(
+        request=RequestCloseReopenSerializer,
+        responses=RequestSerializer,
+        description="Close a request using an available terminal/closed transition.",
+    )
+    @action(detail=True, methods=["post"], url_path="close")
+    def close(self, request, pk=None):
+        serializer = RequestCloseReopenSerializer(data=request.data)
+        if not serializer.is_valid():
+            return validation_error_response(serializer.errors)
+
+        rt_request = self.get_object()
+        transition = find_transition_by_target_category(
+            rt_request, categories={"closed"}, terminal=True
+        )
+        if not transition:
+            return transition_not_available_response(
+                "No close transition is available."
+            )
+
+        updated_request = apply_transition(
+            rt_request=rt_request,
+            transition=transition,
+            action_type="request.closed",
+            comment=serializer.validated_data.get("comment") or "",
+        )
+        return Response(RequestSerializer(updated_request).data)
+
+    @extend_schema(
+        request=RequestCloseReopenSerializer,
+        responses=RequestSerializer,
+        description="Reopen a request using an available open transition.",
+    )
+    @action(detail=True, methods=["post"], url_path="reopen")
+    def reopen(self, request, pk=None):
+        serializer = RequestCloseReopenSerializer(data=request.data)
+        if not serializer.is_valid():
+            return validation_error_response(serializer.errors)
+
+        rt_request = self.get_object()
+        transition = find_transition_by_target_category(rt_request, categories={"open"})
+        if not transition:
+            return transition_not_available_response(
+                "No reopen transition is available."
+            )
+
+        updated_request = apply_transition(
+            rt_request=rt_request,
+            transition=transition,
+            action_type="request.reopened",
+            comment=serializer.validated_data.get("comment") or "",
+        )
+        return Response(RequestSerializer(updated_request).data)
 
 
 class FlowViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
@@ -600,6 +707,86 @@ def format_validation_details(errors):
 
     walk(errors, "")
     return details
+
+
+def validation_error_response(errors):
+    return Response(
+        {
+            "code": "validation_error",
+            "message": "Invalid request payload.",
+            "details": format_validation_details(errors),
+        },
+        status=status.HTTP_400_BAD_REQUEST,
+    )
+
+
+def transition_not_available_response(message):
+    return Response(
+        {
+            "code": "invalid_transition",
+            "message": message,
+            "details": [],
+        },
+        status=status.HTTP_400_BAD_REQUEST,
+    )
+
+
+def get_available_transitions(rt_request):
+    return Transition.objects.filter(
+        flowid=rt_request.flowid_id,
+        fromstatusid=rt_request.statusid_id,
+    ).select_related("tostatusid")
+
+
+def find_transition_by_target_category(rt_request, categories, terminal=False):
+    normalized_categories = {category.lower() for category in categories}
+    for transition in get_available_transitions(rt_request):
+        target = transition.tostatusid
+        category = (target.category or "").lower()
+        if category in normalized_categories or (terminal and target.isterminal):
+            return transition
+    return None
+
+
+@transaction.atomic
+def apply_transition(rt_request, transition, action_type, comment=""):
+    previous_status_id = rt_request.statusid_id
+    now = timezone.now()
+    rt_request.statusid = transition.tostatusid
+    rt_request.updatedat = now
+    rt_request.save(update_fields=["statusid", "updatedat"])
+
+    created_comment = None
+    if comment:
+        created_comment = Comment.objects.create(
+            commentid=uuid.uuid4(),
+            tenantid=rt_request.tenantid,
+            requestid=rt_request,
+            authorid=rt_request.requesterid,
+            messagemd=comment,
+            visibility="public",
+            createdat=now,
+        )
+
+    Activity.objects.create(
+        activityid=uuid.uuid4(),
+        tenantid=rt_request.tenantid,
+        requestid=rt_request,
+        actorid=rt_request.requesterid,
+        type=action_type,
+        payload=json.dumps(
+            {
+                "transition_id": str(transition.transitionid),
+                "from_status_id": str(previous_status_id),
+                "to_status_id": str(transition.tostatusid_id),
+                "comment_id": (
+                    str(created_comment.commentid) if created_comment else None
+                ),
+            }
+        ),
+        createdat=now,
+    )
+    return rt_request
 
 
 def build_storage_url(object_key):

--- a/docs/plans/sprint-2/api-full-request-lifecycle-execplan.md
+++ b/docs/plans/sprint-2/api-full-request-lifecycle-execplan.md
@@ -122,6 +122,14 @@ Behavior:
 
 Add `available-transitions`, `transition`, `close`, and `reopen` endpoints. Validate allowed transitions, create optional comment, and create activity.
 
+Implemented behavior:
+
+- `GET /api/requests/{id}/available-transitions/` lists transitions available from the request current status.
+- `POST /api/requests/{id}/transition/` applies a specific `transition_id`.
+- `POST /api/requests/{id}/close/` applies the first available transition to a closed category or terminal status.
+- `POST /api/requests/{id}/reopen/` applies the first available transition to an open category.
+- Transition actions are tenant-scoped through `RequestViewSet.get_object()`, validate the transition belongs to the request current flow/status, optionally create a public comment, update `updatedat`, and create `Activity` rows.
+
 ### Milestone 5: Dashboard summary
 
 Add `GET /api/dashboard/summary/` returning open, in_progress, waiting, closed, due_today, overdue, assigned_to_me, and unassigned.
@@ -318,7 +326,7 @@ Day 3-4 acceptance:
 - [x] Milestone 3 completed.
   - [x] Postman regression fixed: requester/assignee tenant checks use `Membership`, not `User.tenantid`.
   - [x] Web create-request lookup endpoints added.
-- [ ] Milestone 4 completed.
+- [x] Milestone 4 completed.
 - [ ] Milestone 5 completed.
 - [ ] Milestone 6 completed.
 
@@ -335,6 +343,8 @@ Day 3-4 acceptance:
 - GitHub Actions found a timestamp determinism bug in `RequestViewSet.perform_create`: separate `timezone.now()` calls for `createdat` and `updatedat` can differ by microseconds and make tests flaky.
 - The web cannot create requests ergonomically with raw GUIDs; it needs tenant-scoped lookup endpoints for flows, statuses, and tenant users.
 - Status lookup must verify the parent flow tenant before listing statuses to avoid cross-tenant probing.
+- Workflow transitions are tenant-scoped by first resolving the request through `RequestViewSet.get_object()`; `Transition` itself has no tenant field and is scoped through the request flow and current status.
+- drf-spectacular names request action path parameters with the model lookup field, so generated transition paths use `{requestid}`.
 
 ## Decision Log
 
@@ -348,6 +358,9 @@ Day 3-4 acceptance:
 - Compute the request creation timestamp once and reuse it for both `createdat` and `updatedat`.
 - Register read-only lookup viewsets for flows and users so drf-spectacular emits OpenAPI entries for `/api/flows/`, `/api/flows/{flow_id}/statuses/`, and `/api/users/`.
 - Use `Membership.objects.filter(tenantid=<tenant_id>).values_list("userid_id", flat=True)` to tenant-scope user lookup results.
+- Implement close/reopen as convenience actions over existing `Transition` rows instead of directly setting statuses, preserving workflow rules.
+- Use requester as workflow actor and optional comment author until auth-user to `dbo.User` mapping is introduced.
+- Record workflow activity types as `request.transitioned`, `request.closed`, and `request.reopened`.
 
 ## Outcomes & Retrospective
 
@@ -357,6 +370,7 @@ Milestone 3 complete on `feat/api-create-request-flow`:
 - Create validation enforces tenant-scoped `flow_id`, `status_id`, `requester_id`, optional `assignee_id`, and status-to-flow ownership.
 - User tenant enforcement now checks `Membership`, preventing the SQL/Django `FieldError` seen in Postman.
 - Web lookup endpoints now provide tenant-scoped flow, status, and user options for Create Request.
+- Workflow transition endpoints now expose available transitions and support transition, close, and reopen actions with activity logging.
 - Request creation remains server-owned for `tenantid`, `HumanId`, `createdat`, and `updatedat`.
 - Successful create writes `Activity` type `request.created`.
 - Focused and full pytest verification passed locally.

--- a/tests/test_transitions.py
+++ b/tests/test_transitions.py
@@ -1,0 +1,264 @@
+import json
+import uuid
+from types import SimpleNamespace
+
+from django.test import Client
+from django.urls import resolve
+from django.utils import timezone
+
+from apps.rt.models import Flow, Request, Status, Tenant, Transition, User
+from apps.rt.serializers import (
+    RequestCloseReopenSerializer,
+    RequestTransitionSerializer,
+    TransitionLookupSerializer,
+)
+from apps.rt.views import (
+    RequestViewSet,
+    apply_transition,
+    find_transition_by_target_category,
+    get_available_transitions,
+)
+
+
+class FakeTransitionQuerySet:
+    def __init__(self, transitions):
+        self.transitions = transitions
+        self.select_related_args = None
+        self.get_kwargs = None
+
+    def select_related(self, *fields):
+        self.select_related_args = fields
+        return self
+
+    def get(self, **kwargs):
+        self.get_kwargs = kwargs
+        for transition in self.transitions:
+            if transition.transitionid == kwargs["transitionid"]:
+                return transition
+        raise Transition.DoesNotExist
+
+    def __iter__(self):
+        return iter(self.transitions)
+
+
+def build_request_and_transition(to_category="in_progress", terminal=False):
+    tenant = Tenant(tenantid=uuid.uuid4())
+    flow = Flow(flowid=uuid.uuid4(), tenantid=tenant, name="IT Support")
+    requester = User(userid=uuid.uuid4(), email="requester@example.com")
+    from_status = Status(
+        statusid=uuid.uuid4(),
+        tenantid=tenant,
+        flowid=flow,
+        name="Open",
+        category="open",
+        isterminal=False,
+    )
+    to_status = Status(
+        statusid=uuid.uuid4(),
+        tenantid=tenant,
+        flowid=flow,
+        name="Next",
+        category=to_category,
+        isterminal=terminal,
+    )
+    now = timezone.now()
+    rt_request = Request(
+        requestid=uuid.uuid4(),
+        tenantid=tenant,
+        humanid="RT-2026-000321",
+        title="Transition test",
+        description="Workflow transition.",
+        flowid=flow,
+        statusid=from_status,
+        requesterid=requester,
+        priority="normal",
+        createdat=now,
+        updatedat=now,
+    )
+    transition = Transition(
+        transitionid=uuid.uuid4(),
+        flowid=flow,
+        fromstatusid=from_status,
+        tostatusid=to_status,
+    )
+    return rt_request, transition
+
+
+def test_transition_routes_resolve():
+    request_id = uuid.uuid4()
+
+    assert (
+        resolve(f"/api/requests/{request_id}/available-transitions/").url_name
+        == "requests-available-transitions"
+    )
+    assert (
+        resolve(f"/api/requests/{request_id}/transition/").url_name
+        == "requests-transition"
+    )
+    assert resolve(f"/api/requests/{request_id}/close/").url_name == "requests-close"
+    assert resolve(f"/api/requests/{request_id}/reopen/").url_name == "requests-reopen"
+
+
+def test_transition_serializers_use_public_fields():
+    rt_request, transition = build_request_and_transition()
+
+    assert RequestTransitionSerializer(
+        data={"transition_id": str(transition.transitionid), "comment": "Moving"}
+    ).is_valid()
+    assert RequestCloseReopenSerializer(data={"comment": "Done"}).is_valid()
+    data = TransitionLookupSerializer(transition).data
+
+    assert data["transition_id"] == str(transition.transitionid)
+    assert data["from_status_id"] == str(rt_request.statusid_id)
+    assert data["to_status_id"] == str(transition.tostatusid_id)
+    assert data["to_status"]["category"] == "in_progress"
+
+
+def test_available_transitions_filters_current_flow_and_status(monkeypatch):
+    rt_request, transition = build_request_and_transition()
+    fake_qs = FakeTransitionQuerySet([transition])
+    captured = {}
+
+    def fake_filter(**kwargs):
+        captured.update(kwargs)
+        return fake_qs
+
+    monkeypatch.setattr("apps.rt.views.Transition.objects.filter", fake_filter)
+
+    transitions = get_available_transitions(rt_request)
+
+    assert transitions is fake_qs
+    assert fake_qs.select_related_args == ("tostatusid",)
+    assert captured == {
+        "flowid": rt_request.flowid_id,
+        "fromstatusid": rt_request.statusid_id,
+    }
+
+
+def test_available_transitions_action_returns_lookup_data(monkeypatch):
+    rt_request, transition = build_request_and_transition()
+    monkeypatch.setattr(
+        "apps.rt.views.get_available_transitions",
+        lambda request: [transition],
+    )
+    view = RequestViewSet()
+    view.request = SimpleNamespace(tenant_id=rt_request.tenantid_id)
+    view.get_object = lambda: rt_request
+
+    response = view.available_transitions(view.request, pk=str(rt_request.requestid))
+
+    assert response.status_code == 200
+    assert response.data[0]["transition_id"] == str(transition.transitionid)
+
+
+def test_transition_action_rejects_unavailable_transition(monkeypatch):
+    rt_request, transition = build_request_and_transition()
+    fake_qs = FakeTransitionQuerySet([transition])
+    requested_transition_id = uuid.uuid4()
+    monkeypatch.setattr(
+        "apps.rt.views.get_available_transitions",
+        lambda request: fake_qs,
+    )
+    view = RequestViewSet()
+    view.request = SimpleNamespace(
+        tenant_id=rt_request.tenantid_id,
+        data={"transition_id": str(requested_transition_id)},
+    )
+    view.get_object = lambda: rt_request
+
+    response = view.transition(view.request, pk=str(rt_request.requestid))
+
+    assert response.status_code == 400
+    assert response.data["code"] == "invalid_transition"
+    assert response.data["details"][0]["field"] == "transition_id"
+
+
+def test_apply_transition_updates_status_comment_and_activity(monkeypatch):
+    rt_request, transition = build_request_and_transition(to_category="closed")
+    saved = {}
+    created_comments = []
+    created_activities = []
+
+    def fake_save(**kwargs):
+        saved.update(kwargs)
+
+    monkeypatch.setattr(rt_request, "save", fake_save)
+    monkeypatch.setattr(
+        "apps.rt.views.Comment.objects.create",
+        lambda **kwargs: created_comments.append(SimpleNamespace(**kwargs))
+        or created_comments[-1],
+    )
+    monkeypatch.setattr(
+        "apps.rt.views.Activity.objects.create",
+        lambda **kwargs: created_activities.append(kwargs),
+    )
+
+    apply_transition_without_transaction = apply_transition.__wrapped__
+    updated_request = apply_transition_without_transaction(
+        rt_request,
+        transition,
+        action_type="request.closed",
+        comment="Closing this out.",
+    )
+
+    assert updated_request.statusid == transition.tostatusid
+    assert saved == {"update_fields": ["statusid", "updatedat"]}
+    assert created_comments[0].messagemd == "Closing this out."
+    assert created_activities[0]["type"] == "request.closed"
+    assert created_activities[0]["createdat"] == updated_request.updatedat
+    assert json.loads(created_activities[0]["payload"]) == {
+        "transition_id": str(transition.transitionid),
+        "from_status_id": str(transition.fromstatusid_id),
+        "to_status_id": str(transition.tostatusid_id),
+        "comment_id": str(created_comments[0].commentid),
+    }
+
+
+def test_close_selects_terminal_or_closed_transition(monkeypatch):
+    rt_request, transition = build_request_and_transition(to_category="waiting")
+    terminal_request, terminal_transition = build_request_and_transition(
+        to_category="resolved", terminal=True
+    )
+    terminal_transition.flowid = rt_request.flowid
+    terminal_transition.fromstatusid = rt_request.statusid
+    monkeypatch.setattr(
+        "apps.rt.views.get_available_transitions",
+        lambda request: [transition, terminal_transition],
+    )
+
+    selected = find_transition_by_target_category(
+        rt_request, categories={"closed"}, terminal=True
+    )
+
+    assert selected == terminal_transition
+    assert terminal_request is not None
+
+
+def test_reopen_action_uses_open_transition(monkeypatch):
+    rt_request, transition = build_request_and_transition(to_category="open")
+    monkeypatch.setattr(
+        "apps.rt.views.find_transition_by_target_category",
+        lambda request, categories, terminal=False: transition,
+    )
+    monkeypatch.setattr(
+        "apps.rt.views.apply_transition",
+        lambda rt_request, transition, action_type, comment="": rt_request,
+    )
+    view = RequestViewSet()
+    view.request = SimpleNamespace(tenant_id=rt_request.tenantid_id, data={})
+    view.get_object = lambda: rt_request
+
+    response = view.reopen(view.request, pk=str(rt_request.requestid))
+
+    assert response.status_code == 200
+    assert response.data["request_id"] == str(rt_request.requestid)
+
+
+def test_openapi_schema_includes_transition_paths():
+    response = Client().get("/api/schema")
+
+    assert response.status_code == 200
+    assert b"/api/requests/{requestid}/available-transitions/" in response.content
+    assert b"/api/requests/{requestid}/transition/" in response.content
+    assert b"/api/requests/{requestid}/close/" in response.content
+    assert b"/api/requests/{requestid}/reopen/" in response.content


### PR DESCRIPTION
## Summary
- add available transition, transition, close, and reopen request endpoints
- validate workflow actions against the request current flow/status
- support optional transition comments and activity logging
- expose generated OpenAPI paths for transition actions
- add workflow transition tests and update the Sprint 2 ExecPlan

## Validation
- poetry run pytest -q
- poetry run ruff check .
- poetry run black . --check
- poetry run isort . --check --diff
- git diff --check
- poetry run python manage.py check