### PR TITLE
feat(dashboard): add summary endpoint

### DIFF
--- a/apps/rt/serializers.py
+++ b/apps/rt/serializers.py
@@ -344,6 +344,17 @@ class ActivitySerializer(serializers.ModelSerializer):
         fields = ["activityid", "requestid", "actorid", "type", "payload", "createdat"]
 
 
+class DashboardSummarySerializer(serializers.Serializer):
+    open = serializers.IntegerField()
+    in_progress = serializers.IntegerField()
+    waiting = serializers.IntegerField()
+    closed = serializers.IntegerField()
+    due_today = serializers.IntegerField()
+    overdue = serializers.IntegerField()
+    assigned_to_me = serializers.IntegerField()
+    unassigned = serializers.IntegerField()
+
+
 class SearchQuerySerializer(serializers.Serializer):
     q = serializers.CharField(max_length=200, trim_whitespace=True)
     page = serializers.IntegerField(required=False, min_value=1, default=1)

--- a/apps/rt/views.py
+++ b/apps/rt/views.py
@@ -35,6 +35,7 @@ from .serializers import (
     AttachmentInitResponseSerializer,
     AttachmentSerializer,
     CommentSerializer,
+    DashboardSummarySerializer,
     FlowLookupSerializer,
     RequestCloseReopenSerializer,
     RequestDetailSerializer,
@@ -399,6 +400,32 @@ class UserLookupViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
         return queryset
 
 
+class DashboardSummaryView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    @extend_schema(
+        responses=DashboardSummarySerializer,
+        description="Return tenant-scoped request dashboard KPI counts.",
+    )
+    def get(self, request):
+        tenant_id = getattr(request, "tenant_id", None)
+        if not tenant_id:
+            return Response(
+                {
+                    "code": "tenant_required",
+                    "message": "Tenant context missing.",
+                    "details": [],
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        summary = build_dashboard_summary(
+            queryset=Request.objects.filter(tenantid=tenant_id),
+            user_id=getattr(getattr(request, "user", None), "id", None),
+        )
+        return Response(DashboardSummarySerializer(summary).data)
+
+
 class CommentViewSet(
     mixins.ListModelMixin, mixins.CreateModelMixin, viewsets.GenericViewSet
 ):
@@ -718,6 +745,36 @@ def validation_error_response(errors):
         },
         status=status.HTTP_400_BAD_REQUEST,
     )
+
+
+def build_dashboard_summary(queryset, user_id=None):
+    today = timezone.localdate()
+    open_requests = queryset.filter(statusid__category__iexact="open")
+    in_progress_requests = queryset.filter(statusid__category__iexact="in_progress")
+    waiting_requests = queryset.filter(statusid__category__iexact="waiting")
+    closed_requests = queryset.filter(statusid__category__iexact="closed")
+    active_requests = queryset.exclude(statusid__category__iexact="closed").exclude(
+        statusid__isterminal=True
+    )
+
+    return {
+        "open": open_requests.count(),
+        "in_progress": in_progress_requests.count(),
+        "waiting": waiting_requests.count(),
+        "closed": closed_requests.count(),
+        "due_today": active_requests.filter(dueat__date=today).count(),
+        "overdue": active_requests.filter(dueat__date__lt=today).count(),
+        "assigned_to_me": count_assigned_to_me(queryset, user_id),
+        "unassigned": active_requests.filter(assigneeid__isnull=True).count(),
+    }
+
+
+def count_assigned_to_me(queryset, user_id):
+    try:
+        assignee_id = uuid.UUID(str(user_id))
+    except (TypeError, ValueError, AttributeError):
+        return 0
+    return queryset.filter(assigneeid_id=assignee_id).count()
 
 
 def transition_not_available_response(message):

--- a/docs/plans/sprint-2/api-full-request-lifecycle-execplan.md
+++ b/docs/plans/sprint-2/api-full-request-lifecycle-execplan.md
@@ -134,6 +134,14 @@ Implemented behavior:
 
 Add `GET /api/dashboard/summary/` returning open, in_progress, waiting, closed, due_today, overdue, assigned_to_me, and unassigned.
 
+Implemented behavior:
+
+- `GET /api/dashboard/summary/` and `GET /api/dashboard/summary` return tenant-scoped KPI counts.
+- Counts are based on `Request` rows for the active tenant and status categories: `open`, `in_progress`, `waiting`, and `closed`.
+- `due_today` and `overdue` exclude closed/terminal requests; `due_today` counts requests due on the current local date, while `overdue` counts requests due before today.
+- `assigned_to_me` uses `request.user.id` only when it is a UUID matching `dbo.User.UserId`; otherwise it returns `0` to avoid SQL conversion errors.
+- `unassigned` counts active requests with no assignee.
+
 ### Milestone 6: Notification baseline
 
 Add `apps/rt/services/notification_service.py`. Send Mailhog-visible emails for request created, assigned, comment added, and closed. Email failure must not break the main action.
@@ -327,7 +335,7 @@ Day 3-4 acceptance:
   - [x] Postman regression fixed: requester/assignee tenant checks use `Membership`, not `User.tenantid`.
   - [x] Web create-request lookup endpoints added.
 - [x] Milestone 4 completed.
-- [ ] Milestone 5 completed.
+- [x] Milestone 5 completed.
 - [ ] Milestone 6 completed.
 
 ## Surprises & Discoveries
@@ -345,6 +353,8 @@ Day 3-4 acceptance:
 - Status lookup must verify the parent flow tenant before listing statuses to avoid cross-tenant probing.
 - Workflow transitions are tenant-scoped by first resolving the request through `RequestViewSet.get_object()`; `Transition` itself has no tenant field and is scoped through the request flow and current status.
 - drf-spectacular names request action path parameters with the model lookup field, so generated transition paths use `{requestid}`.
+- Dashboard summary can be implemented as a read-only APIView backed by tenant-filtered `Request` querysets; no new database model or service package was needed.
+- Auth user to `dbo.User` mapping is still not formalized, so `assigned_to_me` must tolerate non-UUID Django user ids and return `0` instead of raising conversion errors.
 
 ## Decision Log
 
@@ -361,6 +371,9 @@ Day 3-4 acceptance:
 - Implement close/reopen as convenience actions over existing `Transition` rows instead of directly setting statuses, preserving workflow rules.
 - Use requester as workflow actor and optional comment author until auth-user to `dbo.User` mapping is introduced.
 - Record workflow activity types as `request.transitioned`, `request.closed`, and `request.reopened`.
+- Expose dashboard summary at `/api/dashboard/summary/` with a no-trailing-slash alias for Postman/client tolerance.
+- Keep `due_today` and `overdue` mutually exclusive by counting overdue as due dates before the current local date.
+- Exclude closed category and terminal statuses from due/overdue/unassigned active-work counts.
 
 ## Outcomes & Retrospective
 
@@ -371,6 +384,7 @@ Milestone 3 complete on `feat/api-create-request-flow`:
 - User tenant enforcement now checks `Membership`, preventing the SQL/Django `FieldError` seen in Postman.
 - Web lookup endpoints now provide tenant-scoped flow, status, and user options for Create Request.
 - Workflow transition endpoints now expose available transitions and support transition, close, and reopen actions with activity logging.
+- Dashboard summary endpoint now returns tenant-scoped KPI counts for the Home dashboard.
 - Request creation remains server-owned for `tenantid`, `HumanId`, `createdat`, and `updatedat`.
 - Successful create writes `Activity` type `request.created`.
 - Focused and full pytest verification passed locally.

--- a/rt_api/urls.py
+++ b/rt_api/urls.py
@@ -14,6 +14,7 @@ from apps.rt.views import (
     AttachmentInitView,
     AttachmentViewSet,
     CommentViewSet,
+    DashboardSummaryView,
     FlowViewSet,
     RequestViewSet,
     SearchView,
@@ -43,6 +44,16 @@ urlpatterns = [
     ),
     path("api/search", SearchView.as_view(), name="search"),
     path("api/search/requests", SearchView.as_view(), name="search-requests"),
+    path(
+        "api/dashboard/summary",
+        DashboardSummaryView.as_view(),
+        name="dashboard-summary",
+    ),
+    path(
+        "api/dashboard/summary/",
+        DashboardSummaryView.as_view(),
+        name="dashboard-summary-slash",
+    ),
     path("api/schema", SpectacularAPIView.as_view(), name="schema"),
     path(
         "api/docs", SpectacularSwaggerView.as_view(url_name="schema"), name="swagger-ui"

--- a/tests/test_dashboard_summary.py
+++ b/tests/test_dashboard_summary.py
@@ -1,0 +1,164 @@
+import uuid
+from types import SimpleNamespace
+
+from django.test import Client
+from django.urls import resolve
+
+from apps.rt.serializers import DashboardSummarySerializer
+from apps.rt.views import (
+    DashboardSummaryView,
+    build_dashboard_summary,
+    count_assigned_to_me,
+)
+
+
+class FakeDashboardQuerySet:
+    def __init__(self, operations=None):
+        self.operations = operations or []
+
+    def filter(self, **kwargs):
+        return FakeDashboardQuerySet(self.operations + [("filter", kwargs)])
+
+    def exclude(self, **kwargs):
+        return FakeDashboardQuerySet(self.operations + [("exclude", kwargs)])
+
+    def count(self):
+        filters = [
+            kwargs for operation, kwargs in self.operations if operation == "filter"
+        ]
+        excludes = [
+            kwargs for operation, kwargs in self.operations if operation == "exclude"
+        ]
+
+        if {"statusid__category__iexact": "open"} in filters:
+            return 4
+        if {"statusid__category__iexact": "in_progress"} in filters:
+            return 3
+        if {"statusid__category__iexact": "waiting"} in filters:
+            return 2
+        if {"statusid__category__iexact": "closed"} in filters:
+            return 5
+        if {"dueat__date": self.today} in filters:
+            return 6
+        if {"dueat__date__lt": self.today} in filters:
+            return 7
+        if {"assigneeid_id": self.user_id} in filters:
+            return 8
+        if {"assigneeid__isnull": True} in filters:
+            assert {"statusid__category__iexact": "closed"} in excludes
+            assert {"statusid__isterminal": True} in excludes
+            return 9
+        return 0
+
+
+def test_dashboard_summary_routes_resolve():
+    assert resolve("/api/dashboard/summary").url_name == "dashboard-summary"
+    assert resolve("/api/dashboard/summary/").url_name == "dashboard-summary-slash"
+
+
+def test_dashboard_summary_serializer_public_fields():
+    data = DashboardSummarySerializer(
+        {
+            "open": 1,
+            "in_progress": 2,
+            "waiting": 3,
+            "closed": 4,
+            "due_today": 5,
+            "overdue": 6,
+            "assigned_to_me": 7,
+            "unassigned": 8,
+        }
+    ).data
+
+    assert data == {
+        "open": 1,
+        "in_progress": 2,
+        "waiting": 3,
+        "closed": 4,
+        "due_today": 5,
+        "overdue": 6,
+        "assigned_to_me": 7,
+        "unassigned": 8,
+    }
+
+
+def test_build_dashboard_summary_counts_tenant_queryset(monkeypatch):
+    user_id = uuid.uuid4()
+    today = object()
+    FakeDashboardQuerySet.today = today
+    FakeDashboardQuerySet.user_id = user_id
+    monkeypatch.setattr("apps.rt.views.timezone.localdate", lambda: today)
+
+    summary = build_dashboard_summary(FakeDashboardQuerySet(), user_id=user_id)
+
+    assert summary == {
+        "open": 4,
+        "in_progress": 3,
+        "waiting": 2,
+        "closed": 5,
+        "due_today": 6,
+        "overdue": 7,
+        "assigned_to_me": 8,
+        "unassigned": 9,
+    }
+
+
+def test_count_assigned_to_me_returns_zero_for_non_uuid_user_id():
+    assert count_assigned_to_me(FakeDashboardQuerySet(), user_id=1) == 0
+    assert count_assigned_to_me(FakeDashboardQuerySet(), user_id=None) == 0
+
+
+def test_dashboard_summary_view_requires_tenant_context():
+    request = SimpleNamespace(tenant_id=None, user=SimpleNamespace(id=uuid.uuid4()))
+
+    response = DashboardSummaryView().get(request)
+
+    assert response.status_code == 400
+    assert response.data == {
+        "code": "tenant_required",
+        "message": "Tenant context missing.",
+        "details": [],
+    }
+
+
+def test_dashboard_summary_view_uses_tenant_scoped_request_queryset(monkeypatch):
+    tenant_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    fake_qs = FakeDashboardQuerySet()
+    captured_filter = {}
+    captured_summary = {}
+
+    def fake_request_filter(**kwargs):
+        captured_filter.update(kwargs)
+        return fake_qs
+
+    def fake_summary(**kwargs):
+        captured_summary.update(kwargs)
+        return {
+            "open": 1,
+            "in_progress": 2,
+            "waiting": 3,
+            "closed": 4,
+            "due_today": 5,
+            "overdue": 6,
+            "assigned_to_me": 7,
+            "unassigned": 8,
+        }
+
+    monkeypatch.setattr("apps.rt.views.Request.objects.filter", fake_request_filter)
+    monkeypatch.setattr("apps.rt.views.build_dashboard_summary", fake_summary)
+    request = SimpleNamespace(tenant_id=tenant_id, user=SimpleNamespace(id=user_id))
+
+    response = DashboardSummaryView().get(request)
+
+    assert response.status_code == 200
+    assert response.data["open"] == 1
+    assert captured_filter == {"tenantid": tenant_id}
+    assert captured_summary == {"queryset": fake_qs, "user_id": user_id}
+
+
+def test_openapi_schema_includes_dashboard_summary_path():
+    response = Client().get("/api/schema")
+
+    assert response.status_code == 200
+    assert b"/api/dashboard/summary/" in response.content


### PR DESCRIPTION
## Summary
- add tenant-scoped dashboard summary endpoint with trailing-slash alias
- return KPI counts for open, in_progress, waiting, closed, due_today, overdue, assigned_to_me, and unassigned
- keep active-work counts from including closed/terminal requests
- add generated OpenAPI coverage and dashboard summary tests
- update the Sprint 2 ExecPlan

## Validation
- poetry run python manage.py check
- poetry run pytest -q
- poetry run ruff check .
- poetry run black . --check
- poetry run isort . --check --diff
- git diff --check